### PR TITLE
Adjusted height, now prints correctly on LP 2824

### DIFF
--- a/label/default.tpl
+++ b/label/default.tpl
@@ -63,7 +63,7 @@
 			padding: 5px;
 			position: relative;
 			width: 200px;
-			height: 110px;
+			height: 100px;
 			overflow: hidden;
 		}
 		.label h1


### PR DESCRIPTION
Fixed height so it will now print on LP 2824 w/o spitting out an extra label. 
