### PR TITLE
Only show address comma if city and state

### DIFF
--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -269,7 +269,7 @@ img.barcode {
 				<p id="customerName">{{ Workorder.Customer.firstName}} {{ Workorder.Customer.lastName}}</p>
 				<p id="customerAddress1">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
 				<p id="customerAddress2">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
-				<p id="customerAddressCity">{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
+				<p id="customerAddressCity">{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.state %}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {% endif %}{{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
 				<p id="customerCompany">{{ Workorder.Customer.company }}
 				{% for ContactPhone in Workorder.Customer.Contact.Phones.ContactPhone %}
 					<p data-automation="customerPhoneNumber">{{ ContactPhone.number }} ({{ ContactPhone.useType }})</p>

--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -269,7 +269,7 @@ img.barcode {
 				<p id="customerName">{{ Workorder.Customer.firstName}} {{ Workorder.Customer.lastName}}</p>
 				<p id="customerAddress1">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
 				<p id="customerAddress2">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
-				<p id="customerAddressCity">{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.state %}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {% endif %}{{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
+				<p id="customerAddressCity">{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.state %}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }}{% endif %} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
 				<p id="customerCompany">{{ Workorder.Customer.company }}
 				{% for ContactPhone in Workorder.Customer.Contact.Phones.ContactPhone %}
 					<p data-automation="customerPhoneNumber">{{ ContactPhone.number }} ({{ ContactPhone.useType }})</p>

--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -269,7 +269,7 @@ img.barcode {
 				<p id="customerName">{{ Workorder.Customer.firstName}} {{ Workorder.Customer.lastName}}</p>
 				<p id="customerAddress1">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
 				<p id="customerAddress2">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
-				<p id="customerAddressCity">{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.state %}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }}{% endif %} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
+				<p id="customerAddressCity">{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.city and Workorder.Customer.Contact.Addresses.ContactAddress.state %}, {% endif %}{{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
 				<p id="customerCompany">{{ Workorder.Customer.company }}
 				{% for ContactPhone in Workorder.Customer.Contact.Phones.ContactPhone %}
 					<p data-automation="customerPhoneNumber">{{ ContactPhone.number }} ({{ ContactPhone.useType }})</p>

--- a/workorder/default.tpl
+++ b/workorder/default.tpl
@@ -175,7 +175,7 @@ img.barcode {
                 <p>{{ Workorder.Customer.firstName}} {{ Workorder.Customer.lastName}}</p>
                 <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
                 <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
-                <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
+                <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.state and Workorder.Customer.Contact.Addresses.ContactAddress.city %}, {% endif %}{{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
                 {% for ContactPhone in Workorder.Customer.Contact.Phones.ContactPhone %}
                     <p>{{ ContactPhone.number }} ({{ ContactPhone.useType }})</p>
                 {% endfor %}


### PR DESCRIPTION
Only show the address comma if customers city and state are available. Now the template shows a comma on a new line which looks bad.
