### PR TITLE
CLD-9340:  Sale receipts display taxed subtotals incorrectly

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -11,6 +11,7 @@
 {# Sale #}
 {% set sale_id_instead_of_ticket_number = false %}  {# Displays the Sale ID instead of the Ticket Number #}
 {% set invoice_as_title = false %}                  {# If print_layout is true, "Invoice" will be displayed instead of "Sales Receipt" on A4/Letter/Email formats #}
+{% set workorders_as_title = false %}               {# Changes the receipt title to "Work Orders" if there is no Salesline items and 1 or more workorders #}
 {% set quote_id_prefix = "" %}                      {# Adds a string of text as a prefix for the Quote ID. Ex: "Q-". To be used when "sale_id_instead_of_ticket_number" is true #}
 {% set sale_id_prefix = "" %}                       {# Adds a string of text as a prefix for the Sales ID. Ex: "S-". To be used when "sale_id_instead_of_ticket_number" is true #}
 
@@ -32,6 +33,8 @@
 {% set show_sale_lines_on_gift_receipt = true %}    {# Displays Sale Lines on Gift Receipts #}
 {% set show_barcode = true %}                       {# Displays barcode at bottom of receipts #}
 {% set show_barcode_sku = true %}                   {# Displays the System ID at the bottom of barcodes #}
+{% set show_workorders_barcode = false %}           {# Displays workorders barcode #}
+{% set show_workorders_barcode_sku = true %}        {# Displays the System ID at the bottom of workorders barcodes #}
 {% set hide_ticket_number_on_quote = false %}       {# Hides the Ticket Number on Quotes #}
 {% set hide_quote_id_on_sale = false %}             {# Hides the Quote ID on Sales #}
 
@@ -234,6 +237,11 @@ p.thankyou {
 .barcodeContainer {
 	margin-top: 15px;
 	text-align: center;
+}
+
+.workorders .barcodeContainer {
+	margin-left: 15px;
+	text-align: left;
 }
 
 dl {
@@ -531,7 +539,7 @@ table.payments td.label {
 			<!-- replace.email_custom_header_msg -->
 			<div>
 				{{ _self.ship_to(Sale) }}
-				{{ _self.header(Sale) }}
+				{{ _self.header(Sale,_context) }}
 				{{ _self.title(Sale,parameters,_context) }}
 				{{ _self.date(Sale) }}
 				{{ _self.sale_details(Sale,_context) }}
@@ -646,7 +654,6 @@ table.payments td.label {
 	{% endif %}
 {% endmacro %}
 
-
 {% macro title(Sale,parameters,options) %}
 	<h1 class="receiptTypeTitle">
 		{% if Sale.calcTotal >= 0 %}
@@ -654,10 +661,20 @@ table.payments td.label {
 				{% if options.invoice_as_title and options.print_layout %}
 					<span class="hide-on-print">
 				{% endif %}
-				{% if parameters.gift_receipt %}Gift{% else %}Sales{% endif %} Receipt
+				{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+					 Work Orders
+				{% else %}
+					{% if parameters.gift_receipt %}Gift{% else %}Sales{% endif %} Receipt
+				{% endif %}
 				{% if options.invoice_as_title and options.print_layout %}
 					</span>
-					<span class="show-on-print">Invoice</span>
+					<span class="show-on-print">
+						{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+							Work Orders
+						{% else %}
+							Invoice
+						{% endif %}
+					</span>
 				{% endif %}
 			{% elseif Sale.voided == 'true' %}
 				{% if options.invoice_as_title and options.print_layout %}
@@ -932,10 +949,10 @@ table.payments td.label {
 					{% endif %}
 					{% for Tax in Sale.TaxClassTotals.Tax %}
 						{% if Tax.taxname and Tax.rate > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Sale.calcTaxable|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Tax.subtotal|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
 						{% endif %}
 						{% if Tax.taxname2 and Tax.rate2 > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Sale.calcTaxable|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Tax.subtotal2|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
 						{% endif %}
 					{% endfor %}
 					<tr><td width="100%">Total Tax</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
@@ -1167,14 +1184,14 @@ table.payments td.label {
 	{% endautoescape %}
 {% endmacro %}
 
-{% macro header(Sale) %}
+{% macro header(Sale,options) %}
 	<div class="receiptHeader">
 		{% set logo_printed = false %}
-		{% if multi_shop_logos %}
-			{% for shop in shop_logo_array if not logo_printed %}
+		{% if options.multi_shop_logos %}
+			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ logo_width }} height="{{ logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}
@@ -1182,7 +1199,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
-			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ logo_width }}" height="{{ logo_height }}" class="logo">
+			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 			{% if show_shop_name_with_logo %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
@@ -1275,7 +1292,18 @@ table.payments td.label {
 			{% for Line in Customer.Workorders.SaleLine %}
 				<tr>
 					{% if Line.MetaData.workorderTotal %}
-						<td class="workorder" colspan="2">{{ _self.lineDescription(Line,options) }}</td>
+						<td class="workorder" colspan="2">
+							{{ _self.lineDescription(Line,options) }}
+							{% if options.show_workorders_barcode %}
+								<p class="barcodeContainer">
+									<img id="barcodeImage"
+											 height="50"
+											 width="250"
+											 class="barcode"
+											 src="/barcode.php?type=receipt&number={{ Line.MetaData.workorderSystemSku }}&&hide_text={{ not options.show_workorders_barcode_sku }}">
+								</p>
+							{% endif %}
+						</td>
 					{% else %}
 						<td>{{ _self.lineDescription(Line,options) }}</td>
 						<td class="amount">{{Line.calcSubtotal|money}}</td>

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -11,6 +11,7 @@
 {# Sale #}
 {% set sale_id_instead_of_ticket_number = false %}  {# Displays the Sale ID instead of the Ticket Number #}
 {% set invoice_as_title = false %}                  {# If print_layout is true, "Invoice" will be displayed instead of "Sales Receipt" on A4/Letter/Email formats #}
+{% set workorders_as_title = false %}               {# Changes the receipt title to "Work Orders" if there is no Salesline items and 1 or more workorders #}
 {% set quote_id_prefix = "" %}                      {# Adds a string of text as a prefix for the Quote ID. Ex: "Q-". To be used when "sale_id_instead_of_ticket_number" is true #}
 {% set sale_id_prefix = "" %}                       {# Adds a string of text as a prefix for the Sales ID. Ex: "S-". To be used when "sale_id_instead_of_ticket_number" is true #}
 
@@ -32,6 +33,8 @@
 {% set show_sale_lines_on_gift_receipt = true %}    {# Displays Sale Lines on Gift Receipts #}
 {% set show_barcode = true %}                       {# Displays barcode at bottom of receipts #}
 {% set show_barcode_sku = true %}                   {# Displays the System ID at the bottom of barcodes #}
+{% set show_workorders_barcode = false %}           {# Displays workorders barcode #}
+{% set show_workorders_barcode_sku = true %}        {# Displays the System ID at the bottom of workorders barcodes #}
 {% set hide_ticket_number_on_quote = false %}       {# Hides the Ticket Number on Quotes #}
 {% set hide_quote_id_on_sale = false %}             {# Hides the Quote ID on Sales #}
 
@@ -234,6 +237,11 @@ p.thankyou {
 .barcodeContainer {
 	margin-top: 15px;
 	text-align: center;
+}
+
+.workorders .barcodeContainer {
+	margin-left: 15px;
+	text-align: left;
 }
 
 dl {
@@ -531,7 +539,7 @@ table.payments td.label {
 			<!-- replace.email_custom_header_msg -->
 			<div>
 				{{ _self.ship_to(Sale) }}
-				{{ _self.header(Sale) }}
+				{{ _self.header(Sale,_context) }}
 				{{ _self.title(Sale,parameters,_context) }}
 				{{ _self.date(Sale) }}
 				{{ _self.sale_details(Sale,_context) }}
@@ -646,7 +654,6 @@ table.payments td.label {
 	{% endif %}
 {% endmacro %}
 
-
 {% macro title(Sale,parameters,options) %}
 	<h1 class="receiptTypeTitle">
 		{% if Sale.calcTotal >= 0 %}
@@ -654,10 +661,20 @@ table.payments td.label {
 				{% if options.invoice_as_title and options.print_layout %}
 					<span class="hide-on-print">
 				{% endif %}
-				{% if parameters.gift_receipt %}Recibo del regalo{% else %}Recibo de ventas{% endif %}
+				{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+					Órdenes de trabajo
+				{% else %}
+					{% if parameters.gift_receipt %}Recibo del regalo{% else %}Recibo de ventas{% endif %}
+				{% endif %}
 				{% if options.invoice_as_title and options.print_layout %}
 					</span>
-					<span class="show-on-print">Factura</span>
+					<span class="show-on-print">
+						{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+							Órdenes de trabajo
+						{% else %}
+							Factura
+						{% endif %}
+					</span>
 				{% endif %}
 			{% elseif Sale.voided == 'true' %}
 				{% if options.invoice_as_title and options.print_layout %}
@@ -932,10 +949,10 @@ table.payments td.label {
 					{% endif %}
 					{% for Tax in Sale.TaxClassTotals.Tax %}
 						{% if Tax.taxname and Tax.rate > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Sale.calcTaxable|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Tax.subtotal|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
 						{% endif %}
 						{% if Tax.taxname2 and Tax.rate2 > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Sale.calcTaxable|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Tax.subtotal2|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
 						{% endif %}
 					{% endfor %}
 					<tr><td width="100%">Total impuestos</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
@@ -1167,14 +1184,14 @@ table.payments td.label {
 	{% endautoescape %}
 {% endmacro %}
 
-{% macro header(Sale) %}
+{% macro header(Sale,options) %}
 	<div class="receiptHeader">
 		{% set logo_printed = false %}
-		{% if multi_shop_logos %}
-			{% for shop in shop_logo_array if not logo_printed %}
+		{% if options.multi_shop_logos %}
+			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ logo_width }} height="{{ logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}
@@ -1182,7 +1199,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
-			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ logo_width }}" height="{{ logo_height }}" class="logo">
+			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 			{% if show_shop_name_with_logo %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
@@ -1275,7 +1292,18 @@ table.payments td.label {
 			{% for Line in Customer.Workorders.SaleLine %}
 				<tr>
 					{% if Line.MetaData.workorderTotal %}
-						<td class="workorder" colspan="2">{{ _self.lineDescription(Line,options) }}</td>
+						<td class="workorder" colspan="2">
+							{{ _self.lineDescription(Line,options) }}
+							{% if options.show_workorders_barcode %}
+								<p class="barcodeContainer">
+									<img id="barcodeImage"
+											 height="50"
+											 width="250"
+											 class="barcode"
+											 src="/barcode.php?type=receipt&number={{ Line.MetaData.workorderSystemSku }}&&hide_text={{ not options.show_workorders_barcode_sku }}">
+								</p>
+							{% endif %}
+						</td>
 					{% else %}
 						<td>{{ _self.lineDescription(Line,options) }}</td>
 						<td class="amount">{{Line.calcSubtotal|money}}</td>

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -11,6 +11,7 @@
 {# Sale #}
 {% set sale_id_instead_of_ticket_number = false %}  {# Displays the Sale ID instead of the Ticket Number #}
 {% set invoice_as_title = false %}                  {# If print_layout is true, "Invoice" will be displayed instead of "Sales Receipt" on A4/Letter/Email formats #}
+{% set workorders_as_title = false %}               {# Changes the receipt title to "Work Orders" if there is no Salesline items and 1 or more workorders #}
 {% set quote_id_prefix = "" %}                      {# Adds a string of text as a prefix for the Quote ID. Ex: "Q-". To be used when "sale_id_instead_of_ticket_number" is true #}
 {% set sale_id_prefix = "" %}                       {# Adds a string of text as a prefix for the Sales ID. Ex: "S-". To be used when "sale_id_instead_of_ticket_number" is true #}
 
@@ -32,6 +33,8 @@
 {% set show_sale_lines_on_gift_receipt = true %}    {# Displays Sale Lines on Gift Receipts #}
 {% set show_barcode = true %}                       {# Displays barcode at bottom of receipts #}
 {% set show_barcode_sku = true %}                   {# Displays the System ID at the bottom of barcodes #}
+{% set show_workorders_barcode = false %}           {# Displays workorders barcode #}
+{% set show_workorders_barcode_sku = true %}        {# Displays the System ID at the bottom of workorders barcodes #}
 {% set hide_ticket_number_on_quote = false %}       {# Hides the Ticket Number on Quotes #}
 {% set hide_quote_id_on_sale = false %}             {# Hides the Quote ID on Sales #}
 
@@ -234,6 +237,11 @@ p.thankyou {
 .barcodeContainer {
 	margin-top: 15px;
 	text-align: center;
+}
+
+.workorders .barcodeContainer {
+	margin-left: 15px;
+	text-align: left;
 }
 
 dl {
@@ -531,7 +539,7 @@ table.payments td.label {
 			<!-- replace.email_custom_header_msg -->
 			<div>
 				{{ _self.ship_to(Sale) }}
-				{{ _self.header(Sale) }}
+				{{ _self.header(Sale,_context) }}
 				{{ _self.title(Sale,parameters,_context) }}
 				{{ _self.date(Sale) }}
 				{{ _self.sale_details(Sale,_context) }}
@@ -646,7 +654,6 @@ table.payments td.label {
 	{% endif %}
 {% endmacro %}
 
-
 {% macro title(Sale,parameters,options) %}
 	<h1 class="receiptTypeTitle">
 		{% if Sale.calcTotal >= 0 %}
@@ -654,10 +661,20 @@ table.payments td.label {
 				{% if options.invoice_as_title and options.print_layout %}
 					<span class="hide-on-print">
 				{% endif %}
-				{% if parameters.gift_receipt %}Reçu cadeau{% else %}Reçu de vente{% endif %}
+				{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+					Demandes de service
+				{% else %}
+					{% if parameters.gift_receipt %}Reçu cadeau{% else %}Reçu de vente{% endif %}
+				{% endif %}
 				{% if options.invoice_as_title and options.print_layout %}
 					</span>
-					<span class="show-on-print">Facture</span>
+					<span class="show-on-print">
+						{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+							Demandes de service
+						{% else %}
+							Facture
+						{% endif %}
+					</span>
 				{% endif %}
 			{% elseif Sale.voided == 'true' %}
 				{% if options.invoice_as_title and options.print_layout %}
@@ -932,10 +949,10 @@ table.payments td.label {
 					{% endif %}
 					{% for Tax in Sale.TaxClassTotals.Tax %}
 						{% if Tax.taxname and Tax.rate > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Sale.calcTaxable|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Tax.subtotal|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
 						{% endif %}
 						{% if Tax.taxname2 and Tax.rate2 > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Sale.calcTaxable|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Tax.subtotal2|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
 						{% endif %}
 					{% endfor %}
 					<tr><td width="100%">Total des taxes</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
@@ -1167,14 +1184,14 @@ table.payments td.label {
 	{% endautoescape %}
 {% endmacro %}
 
-{% macro header(Sale) %}
+{% macro header(Sale,options) %}
 	<div class="receiptHeader">
 		{% set logo_printed = false %}
-		{% if multi_shop_logos %}
-			{% for shop in shop_logo_array if not logo_printed %}
+		{% if options.multi_shop_logos %}
+			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ logo_width }} height="{{ logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}
@@ -1182,7 +1199,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
-			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ logo_width }}" height="{{ logo_height }}" class="logo">
+			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 			{% if show_shop_name_with_logo %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
@@ -1275,7 +1292,18 @@ table.payments td.label {
 			{% for Line in Customer.Workorders.SaleLine %}
 				<tr>
 					{% if Line.MetaData.workorderTotal %}
-						<td class="workorder" colspan="2">{{ _self.lineDescription(Line,options) }}</td>
+						<td class="workorder" colspan="2">
+							{{ _self.lineDescription(Line,options) }}
+							{% if options.show_workorders_barcode %}
+								<p class="barcodeContainer">
+									<img id="barcodeImage"
+											 height="50"
+											 width="250"
+											 class="barcode"
+											 src="/barcode.php?type=receipt&number={{ Line.MetaData.workorderSystemSku }}&&hide_text={{ not options.show_workorders_barcode_sku }}">
+								</p>
+							{% endif %}
+						</td>
 					{% else %}
 						<td>{{ _self.lineDescription(Line,options) }}</td>
 						<td class="amount">{{Line.calcSubtotal|money}}</td>

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -11,6 +11,7 @@
 {# Sale #}
 {% set sale_id_instead_of_ticket_number = false %}  {# Displays the Sale ID instead of the Ticket Number #}
 {% set invoice_as_title = false %}                  {# If print_layout is true, "Invoice" will be displayed instead of "Sales Receipt" on A4/Letter/Email formats #}
+{% set workorders_as_title = false %}               {# Changes the receipt title to "Work Orders" if there is no Salesline items and 1 or more workorders #}
 {% set quote_id_prefix = "" %}                      {# Adds a string of text as a prefix for the Quote ID. Ex: "Q-". To be used when "sale_id_instead_of_ticket_number" is true #}
 {% set sale_id_prefix = "" %}                       {# Adds a string of text as a prefix for the Sales ID. Ex: "S-". To be used when "sale_id_instead_of_ticket_number" is true #}
 
@@ -32,6 +33,8 @@
 {% set show_sale_lines_on_gift_receipt = true %}    {# Displays Sale Lines on Gift Receipts #}
 {% set show_barcode = true %}                       {# Displays barcode at bottom of receipts #}
 {% set show_barcode_sku = true %}                   {# Displays the System ID at the bottom of barcodes #}
+{% set show_workorders_barcode = false %}           {# Displays workorders barcode #}
+{% set show_workorders_barcode_sku = true %}        {# Displays the System ID at the bottom of workorders barcodes #}
 {% set hide_ticket_number_on_quote = false %}       {# Hides the Ticket Number on Quotes #}
 {% set hide_quote_id_on_sale = false %}             {# Hides the Quote ID on Sales #}
 
@@ -234,6 +237,11 @@ p.thankyou {
 .barcodeContainer {
 	margin-top: 15px;
 	text-align: center;
+}
+
+.workorders .barcodeContainer {
+	margin-left: 15px;
+	text-align: left;
 }
 
 dl {
@@ -531,7 +539,7 @@ table.payments td.label {
 			<!-- replace.email_custom_header_msg -->
 			<div>
 				{{ _self.ship_to(Sale) }}
-				{{ _self.header(Sale) }}
+				{{ _self.header(Sale,_context) }}
 				{{ _self.title(Sale,parameters,_context) }}
 				{{ _self.date(Sale) }}
 				{{ _self.sale_details(Sale,_context) }}
@@ -646,7 +654,6 @@ table.payments td.label {
 	{% endif %}
 {% endmacro %}
 
-
 {% macro title(Sale,parameters,options) %}
 	<h1 class="receiptTypeTitle">
 		{% if Sale.calcTotal >= 0 %}
@@ -654,10 +661,20 @@ table.payments td.label {
 				{% if options.invoice_as_title and options.print_layout %}
 					<span class="hide-on-print">
 				{% endif %}
-				{% if parameters.gift_receipt %}Geschenkbewijs{% else %}Ontvangstbewijs{% endif %}
+				{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+					Werkbonnen
+				{% else %}
+					{% if parameters.gift_receipt %}Geschenkbewijs{% else %}Ontvangstbewijs{% endif %}
+				{% endif %}
 				{% if options.invoice_as_title and options.print_layout %}
 					</span>
-					<span class="show-on-print">Factuur</span>
+					<span class="show-on-print">
+						{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+							Werkbonnen
+						{% else %}
+							Factuur
+						{% endif %}
+					</span>
 				{% endif %}
 			{% elseif Sale.voided == 'true' %}
 				{% if options.invoice_as_title and options.print_layout %}
@@ -932,10 +949,10 @@ table.payments td.label {
 					{% endif %}
 					{% for Tax in Sale.TaxClassTotals.Tax %}
 						{% if Tax.taxname and Tax.rate > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Sale.calcTaxable|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Tax.subtotal|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
 						{% endif %}
 						{% if Tax.taxname2 and Tax.rate2 > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Sale.calcTaxable|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Tax.subtotal2|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
 						{% endif %}
 					{% endfor %}
 					<tr><td width="100%">Totaal belasting</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
@@ -1167,14 +1184,14 @@ table.payments td.label {
 	{% endautoescape %}
 {% endmacro %}
 
-{% macro header(Sale) %}
+{% macro header(Sale,options) %}
 	<div class="receiptHeader">
 		{% set logo_printed = false %}
-		{% if multi_shop_logos %}
-			{% for shop in shop_logo_array if not logo_printed %}
+		{% if options.multi_shop_logos %}
+			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ logo_width }} height="{{ logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}
@@ -1182,7 +1199,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
-			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ logo_width }}" height="{{ logo_height }}" class="logo">
+			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 			{% if show_shop_name_with_logo %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
@@ -1275,7 +1292,18 @@ table.payments td.label {
 			{% for Line in Customer.Workorders.SaleLine %}
 				<tr>
 					{% if Line.MetaData.workorderTotal %}
-						<td class="workorder" colspan="2">{{ _self.lineDescription(Line,options) }}</td>
+						<td class="workorder" colspan="2">
+							{{ _self.lineDescription(Line,options) }}
+							{% if options.show_workorders_barcode %}
+								<p class="barcodeContainer">
+									<img id="barcodeImage"
+											 height="50"
+											 width="250"
+											 class="barcode"
+											 src="/barcode.php?type=receipt&number={{ Line.MetaData.workorderSystemSku }}&&hide_text={{ not options.show_workorders_barcode_sku }}">
+								</p>
+							{% endif %}
+						</td>
 					{% else %}
 						<td>{{ _self.lineDescription(Line,options) }}</td>
 						<td class="amount">{{Line.calcSubtotal|money}}</td>

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -11,6 +11,7 @@
 {# Sale #}
 {% set sale_id_instead_of_ticket_number = false %}  {# Displays the Sale ID instead of the Ticket Number #}
 {% set invoice_as_title = false %}                  {# If print_layout is true, "Invoice" will be displayed instead of "Sales Receipt" on A4/Letter/Email formats #}
+{% set workorders_as_title = false %}               {# Changes the receipt title to "Work Orders" if there is no Salesline items and 1 or more workorders #}
 {% set quote_id_prefix = "" %}                      {# Adds a string of text as a prefix for the Quote ID. Ex: "Q-". To be used when "sale_id_instead_of_ticket_number" is true #}
 {% set sale_id_prefix = "" %}                       {# Adds a string of text as a prefix for the Sales ID. Ex: "S-". To be used when "sale_id_instead_of_ticket_number" is true #}
 
@@ -32,6 +33,8 @@
 {% set show_sale_lines_on_gift_receipt = true %}    {# Displays Sale Lines on Gift Receipts #}
 {% set show_barcode = true %}                       {# Displays barcode at bottom of receipts #}
 {% set show_barcode_sku = true %}                   {# Displays the System ID at the bottom of barcodes #}
+{% set show_workorders_barcode = false %}           {# Displays workorders barcode #}
+{% set show_workorders_barcode_sku = true %}        {# Displays the System ID at the bottom of workorders barcodes #}
 {% set hide_ticket_number_on_quote = false %}       {# Hides the Ticket Number on Quotes #}
 {% set hide_quote_id_on_sale = false %}             {# Hides the Quote ID on Sales #}
 
@@ -234,6 +237,11 @@ p.thankyou {
 .barcodeContainer {
 	margin-top: 15px;
 	text-align: center;
+}
+
+.workorders .barcodeContainer {
+	margin-left: 15px;
+	text-align: left;
 }
 
 dl {
@@ -531,7 +539,7 @@ table.payments td.label {
 			<!-- replace.email_custom_header_msg -->
 			<div>
 				{{ _self.ship_to(Sale) }}
-				{{ _self.header(Sale) }}
+				{{ _self.header(Sale,_context) }}
 				{{ _self.title(Sale,parameters,_context) }}
 				{{ _self.date(Sale) }}
 				{{ _self.sale_details(Sale,_context) }}
@@ -646,7 +654,6 @@ table.payments td.label {
 	{% endif %}
 {% endmacro %}
 
-
 {% macro title(Sale,parameters,options) %}
 	<h1 class="receiptTypeTitle">
 		{% if Sale.calcTotal >= 0 %}
@@ -654,10 +661,20 @@ table.payments td.label {
 				{% if options.invoice_as_title and options.print_layout %}
 					<span class="hide-on-print">
 				{% endif %}
-				{% if parameters.gift_receipt %}Cadeaubon{% else %}Bon{% endif %}
+				{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+					Werkbonnen
+				{% else %}
+					{% if parameters.gift_receipt %}Cadeaubon{% else %}Bon{% endif %}
+				{% endif %}
 				{% if options.invoice_as_title and options.print_layout %}
 					</span>
-					<span class="show-on-print">Factuur</span>
+					<span class="show-on-print">
+						{% if options.workorders_as_title and Sale.SaleLines is empty and Sale.Customer.Workorders is defined %}
+							Werkbonnen
+						{% else %}
+							Factuur
+						{% endif %}
+					</span>
 				{% endif %}
 			{% elseif Sale.voided == 'true' %}
 				{% if options.invoice_as_title and options.print_layout %}
@@ -932,10 +949,10 @@ table.payments td.label {
 					{% endif %}
 					{% for Tax in Sale.TaxClassTotals.Tax %}
 						{% if Tax.taxname and Tax.rate > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Sale.calcTaxable|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname}} ({{Tax.subtotal|money}} @ {{Tax.rate}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount|money}}</td></tr>
 						{% endif %}
 						{% if Tax.taxname2 and Tax.rate2 > 0 %}
-							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Sale.calcTaxable|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
+							<tr><td data-automation="receiptSaleTotalsTaxName" width="100%">{{Tax.taxname2}} ({{Tax.subtotal2|money}} @ {{Tax.rate2}}%)</td><td data-automation="receiptSaleTotalsTaxValue" class="amount">{{Tax.amount2|money}}</td></tr>
 						{% endif %}
 					{% endfor %}
 					<tr><td width="100%">Totaal belasting</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
@@ -1167,14 +1184,14 @@ table.payments td.label {
 	{% endautoescape %}
 {% endmacro %}
 
-{% macro header(Sale) %}
+{% macro header(Sale,options) %}
 	<div class="receiptHeader">
 		{% set logo_printed = false %}
-		{% if multi_shop_logos %}
-			{% for shop in shop_logo_array if not logo_printed %}
+		{% if options.multi_shop_logos %}
+			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ logo_width }} height="{{ logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}
@@ -1182,7 +1199,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
-			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ logo_width }}" height="{{ logo_height }}" class="logo">
+			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 			{% if show_shop_name_with_logo %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
@@ -1275,7 +1292,18 @@ table.payments td.label {
 			{% for Line in Customer.Workorders.SaleLine %}
 				<tr>
 					{% if Line.MetaData.workorderTotal %}
-						<td class="workorder" colspan="2">{{ _self.lineDescription(Line,options) }}</td>
+						<td class="workorder" colspan="2">
+							{{ _self.lineDescription(Line,options) }}
+							{% if options.show_workorders_barcode %}
+								<p class="barcodeContainer">
+									<img id="barcodeImage"
+											 height="50"
+											 width="250"
+											 class="barcode"
+											 src="/barcode.php?type=receipt&number={{ Line.MetaData.workorderSystemSku }}&&hide_text={{ not options.show_workorders_barcode_sku }}">
+								</p>
+							{% endif %}
+						</td>
 					{% else %}
 						<td>{{ _self.lineDescription(Line,options) }}</td>
 						<td class="amount">{{Line.calcSubtotal|money}}</td>


### PR DESCRIPTION
Fix the subtotal amount to be the tax amount and not the sale amount.