### PR TITLE
CLD-18928 Receipt line is always printed with PHP 7

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -551,7 +551,7 @@ table.payments td.label {
 						{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 						{% set page_loaded = true %}
 					{% else %}
-						{% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature == true %}
+						{% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 							{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 							{% set page_loaded = true %}
 						{% endif %}
@@ -1277,7 +1277,7 @@ table.payments td.label {
 {% endmacro %}
 
 {% macro cc_agreement(Sale,Payment,options) %}
-	{% if Payment.MetaData.ReceiptData.requires_receipt_signature == true %}
+	{% if Payment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 		{% if Sale.Shop.ReceiptSetup.creditcardAgree|strlen > 0 %}
 			<p>{{Sale.Shop.ReceiptSetup.creditcardAgree|noteformat|raw}}</p>
 		{% endif %}

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -533,7 +533,7 @@ table.payments td.label {
 						{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 						{% set page_loaded = true %}
 					{% else %}
-                        {% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature == true %}
+                        {% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 							{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 							{% set page_loaded = true %}
 						{% endif %}
@@ -1122,7 +1122,7 @@ table.payments td.label {
 {% endmacro %}
 
 {% macro cc_agreement(Sale,Payment,options) %}
-	{% if Payment.MetaData.ReceiptData.requires_receipt_signature == true %}
+	{% if Payment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 		{% if Sale.Shop.ReceiptSetup.creditcardAgree|strlen > 0 %}
 			<p>{{Sale.Shop.ReceiptSetup.creditcardAgree|noteformat|raw}}</p>
 		{% endif %}

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -533,7 +533,7 @@ table.payments td.label {
 						{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 						{% set page_loaded = true %}
 					{% else %}
-                        {% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature == true %}
+                        {% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 							{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 							{% set page_loaded = true %}
 						{% endif %}
@@ -1122,7 +1122,7 @@ table.payments td.label {
 {% endmacro %}
 
 {% macro cc_agreement(Sale,Payment,options) %}
-	{% if Payment.MetaData.ReceiptData.requires_receipt_signature == true %}
+	{% if Payment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 		{% if Sale.Shop.ReceiptSetup.creditcardAgree|strlen > 0 %}
 			<p>{{Sale.Shop.ReceiptSetup.creditcardAgree|noteformat|raw}}</p>
 		{% endif %}

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -537,7 +537,7 @@ table.payments td.label {
 						{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 						{% set page_loaded = true %}
 					{% else %}
-						{% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature == true %}
+						{% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 							{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 							{% set page_loaded = true %}
 						{% endif %}
@@ -1126,7 +1126,7 @@ table.payments td.label {
 {% endmacro %}
 
 {% macro cc_agreement(Sale,Payment,options) %}
-	{% if Payment.MetaData.ReceiptData.requires_receipt_signature == true %}
+	{% if Payment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 		{% if Sale.Shop.ReceiptSetup.creditcardAgree|strlen > 0 %}
 			<p>{{Sale.Shop.ReceiptSetup.creditcardAgree|noteformat|raw}}</p>
 		{% endif %}

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -533,7 +533,7 @@ table.payments td.label {
 						{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 						{% set page_loaded = true %}
 					{% else %}
-						{% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature == true %}
+						{% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 							{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 							{% set page_loaded = true %}
 						{% endif %}
@@ -1122,7 +1122,7 @@ table.payments td.label {
 {% endmacro %}
 
 {% macro cc_agreement(Sale,Payment,options) %}
-	{% if Payment.MetaData.ReceiptData.requires_receipt_signature == true %}
+	{% if Payment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 		{% if Sale.Shop.ReceiptSetup.creditcardAgree|strlen > 0 %}
 			<p>{{Sale.Shop.ReceiptSetup.creditcardAgree|noteformat|raw}}</p>
 		{% endif %}

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -533,7 +533,7 @@ table.payments td.label {
 						{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 						{% set page_loaded = true %}
 					{% else %}
-						{% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature == true %}
+						{% if SalePayment.archived == 'false' and SalePayment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 							{{ _self.store_receipt(Sale,parameters,_context,SalePayment) }}
 							{% set page_loaded = true %}
 						{% endif %}
@@ -1122,7 +1122,7 @@ table.payments td.label {
 {% endmacro %}
 
 {% macro cc_agreement(Sale,Payment,options) %}
-	{% if Payment.MetaData.ReceiptData.requires_receipt_signature == true %}
+	{% if Payment.MetaData.ReceiptData.requires_receipt_signature|CompBool == true %}
 		{% if Sale.Shop.ReceiptSetup.creditcardAgree|strlen > 0 %}
 			<p>{{Sale.Shop.ReceiptSetup.creditcardAgree|noteformat|raw}}</p>
 		{% endif %}


### PR DESCRIPTION
The Twig templates used for receipts compare a SimpleXmlElement
to `true`. Sometimes the SimpleXmlElement is empty.
On PHP 5.6 Twig evaluates this empty element to `false` but on
PHP 7.2 it evaluates it to `true`.

This change adds the `CompBool` filter to these comparisons.

This is a copy of https://github.com/merchantos/webPOS/pull/10953