### PR TITLE
CLD-28090 templates updates: Internal notes display and Belgium rounding

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -517,6 +517,7 @@ table.payments td.label {
 		}
 
 		.paymentTitle,
+		.notesTitle,
 		.footerSectionTitle {
 			font-size: 12pt;
 			padding-top: 15px;
@@ -524,6 +525,10 @@ table.payments td.label {
 		}
 		.footerSectionTitle {
 			clear: both;
+		}
+		.notesTitle {
+			float: left;
+			width: 100%;
 		}
 
 		.thankyou {
@@ -941,7 +946,7 @@ table.payments td.label {
 	{% if Sale.SaleLines %}
 		<table class="sale lines">
 			<tr>
-				<th class="description">Item</th>
+				<th class="description">Items</th>
 
 				{% if options.show_custom_sku and options.show_manufacturer_sku %}
 					<th class="custom_field">Custom SKU</th>
@@ -1534,7 +1539,7 @@ table.payments td.label {
 {% macro show_note(SaleNotes) %}
 	{% for SaleNote in SaleNotes %}
 		{% if SaleNote.PrintedNote and SaleNote.PrintedNote.note != '' %}
-			<h2 class="paymentTitle">NOTES</h2>
+			<h2 class="notesTitle">NOTES</h2>
 			<table>
 				<tr>
 					<td>

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -499,6 +499,7 @@ table.payments td.label {
 		}
 
 		.paymentTitle,
+		.notesTitle,
 		.footerSectionTitle {
 			font-size: 12pt;
 			padding-top: 15px;
@@ -506,6 +507,10 @@ table.payments td.label {
 		}
 		.footerSectionTitle {
 			clear: both;
+		}
+		.notesTitle {
+			float: left;
+			width: 100%;
 		}
 
 		.thankyou {
@@ -1372,7 +1377,7 @@ table.payments td.label {
 {% macro show_note(SaleNotes) %}
 	{% for SaleNote in SaleNotes %}
 		{% if SaleNote.PrintedNote and SaleNote.PrintedNote.note != '' %}
-			<h2 class="paymentTitle">Bemerkung</h2>
+			<h2 class="notesTitle">Bemerkung</h2>
 			<table>
 				<tr>
 					<td>

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -499,6 +499,7 @@ table.payments td.label {
 		}
 
 		.paymentTitle,
+		.notesTitle,
 		.footerSectionTitle {
 			font-size: 12pt;
 			padding-top: 15px;
@@ -506,6 +507,10 @@ table.payments td.label {
 		}
 		.footerSectionTitle {
 			clear: both;
+		}
+		.notesTitle {
+			float: left;
+			width: 100%;
 		}
 
 		.thankyou {
@@ -1372,7 +1377,7 @@ table.payments td.label {
 {% macro show_note(SaleNotes) %}
 	{% for SaleNote in SaleNotes %}
 		{% if SaleNote.PrintedNote and SaleNote.PrintedNote.note != '' %}
-			<h2 class="paymentTitle">NOTAS</h2>
+			<h2 class="notesTitle">NOTAS</h2>
 			<table>
 				<tr>
 					<td>

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -499,6 +499,7 @@ table.payments td.label {
 		}
 
 		.paymentTitle,
+		.notesTitle,
 		.footerSectionTitle {
 			font-size: 12pt;
 			padding-top: 15px;
@@ -506,6 +507,10 @@ table.payments td.label {
 		}
 		.footerSectionTitle {
 			clear: both;
+		}
+		.notesTitle {
+			float: left;
+			width: 100%;
 		}
 
 		.thankyou {
@@ -970,7 +975,27 @@ table.payments td.label {
 						{% endif %}
 					{% endfor %}
 					<tr><td width="100%">Total des taxes</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
-					<tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% set cash_total = 0 %}
+                    {% set non_cash_total =  0 %}
+                    {% for Payment in Sale.SalePayments.SalePayment %}
+                        {% if Payment.PaymentType.code == "Cash" %}
+                            {% set cash_total = cash_total + Payment.amount|floatval %}
+                        {% else %}
+                            {% set non_cash_total = non_cash_total + Payment.amount|floatval %}
+                        {% endif %}
+                    {% endfor %}
+                        {% set roundedCashTotal = ((cash_total * 20) | round) / 20 %}
+                        {% set roundedTotal = roundedCashTotal + non_cash_total %}
+                    {% if roundedTotal != Sale.calcTotal %}
+                        {% if Sale.completed == "false" and Sale.quoteID > 0 %}
+                            <tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                        {% else %}
+                            <tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                            <tr class="total"><td>Total arrondi</td><td id="receiptSaleTotalsRoundedTotal" class="amount">{{roundedTotal|money}}</td></tr>
+                        {% endif %}
+                    {% else %}
+                        <tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}
@@ -1355,24 +1380,45 @@ table.payments td.label {
 {% endmacro %}
 
 {% macro sale_cash_payment(Sale) %}
-	{% set total = Sale.change|floatval %}
-	{% set pay_cash = 'false' %}
-	{% for Payment in Sale.SalePayments.SalePayment %}
-		{% if Payment.PaymentType.name == 'Cash' and Payment.archived == 'false' %}
-			{% set total = total + Payment.amount|floatval %}
-			{% set pay_cash = 'true' %}
-		{% endif %}
-	{% endfor %}
-	{% if pay_cash == 'true' %}
-		<tr><td class="label">Comptant</td><td id="receiptPaymentsCash" class="amount">{{total|money}}</td></tr>
-		<tr><td class="label">Monnaie</td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
-	{% endif %}
+	{% set cashTotal = 0 %}
+	{% set payCash = 'false' %}
+		{% for Payment in Sale.SalePayments.SalePayment %}
+			{% if Payment.PaymentType.code == 'Cash' %}
+            	{% set cashTotal = cashTotal + Payment.amount|floatval %}
+            	{% set payCash = 'true' %}
+        	{% endif %}
+    	{% endfor %}
+	{% if payCash == 'true' %}
+		{% set roundedCashChange = (((Sale.change|floatval) * 20) | round) / 20 %}
+		{% set roundedCashAmount = (((cashTotal * 20)|round) / 20) %}
+		{% set originalCashPayedTotalValue = Sale.change|floatval + cashTotal %}
+		{% set roundedCashPayedTotalValue = roundedCashAmount + Sale.change|floatval %}
+			<tr><td>Montant payé en espèces</td><td>{{originalCashPayedTotalValue|money}}</td></tr>
+		{% if originalCashPayedTotalValue == roundedCashPayedTotalValue %}
+        	<tr><td class="label">Espèces</td><td id="receiptPaymentsCash" class="amount">{{cashTotal|money}}</td></tr>
+        	{% if (Sale.change|floatval) != roundedCashChange %}
+        	<tr><td class="label">Monnaie</td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
+        	<tr><td class="label">Arrondi de la monnaie rendue</td><td id="receiptPaymentsChange" class="amount">{{roundedCashChange|money}}</td></tr>
+        	{% else %}
+        	<tr><td class="label">Monnaie</td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
+        	{% endif %}
+    	{% else %}
+        	<tr><td class="label">Espèces</td><td id="receiptPaymentsCash" class="amount">{{cashTotal|money}}</td></tr>
+        	<tr><td class="label">Total arrondi en espèces </td><td id="receiptRoundedPaymentsCash" class="amount">{{roundedCashAmount|money}}</td></tr>
+            {% if (Sale.change|floatval) != roundedCashChange %}
+        	<tr><td class="label">Monnaie </td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
+        	<tr><td class="label"> Arrondi de la monnaie rendue </td><td id="receiptRoundedPaymentsChange" class="amount">{{roundedCashChange|money}}</td></tr>
+        	{% else %}
+        	<tr><td class="label">Monnaie </td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
+        	{% endif %}
+    	{% endif %}
+   	{% endif %}
 {% endmacro %}
 
 {% macro show_note(SaleNotes) %}
 	{% for SaleNote in SaleNotes %}
 		{% if SaleNote.PrintedNote and SaleNote.PrintedNote.note != '' %}
-			<h2 class="paymentTitle">NOTES</h2>
+			<h2 class="notesTitle">NOTES</h2>
 			<table>
 				<tr>
 					<td>

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -499,6 +499,7 @@ table.payments td.label {
 		}
 
 		.paymentTitle,
+		.notesTitle,
 		.footerSectionTitle {
 			font-size: 12pt;
 			padding-top: 15px;
@@ -506,6 +507,10 @@ table.payments td.label {
 		}
 		.footerSectionTitle {
 			clear: both;
+		}
+		.notesTitle {
+			float: left;
+			width: 100%;
 		}
 
 		.thankyou {
@@ -1372,7 +1377,7 @@ table.payments td.label {
 {% macro show_note(SaleNotes) %}
 	{% for SaleNote in SaleNotes %}
 		{% if SaleNote.PrintedNote and SaleNote.PrintedNote.note != '' %}
-			<h2 class="paymentTitle">Note</h2>
+			<h2 class="notesTitle">Note</h2>
 			<table>
 				<tr>
 					<td>

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -499,6 +499,7 @@ table.payments td.label {
 		}
 
 		.paymentTitle,
+		.notesTitle,
 		.footerSectionTitle {
 			font-size: 12pt;
 			padding-top: 15px;
@@ -506,6 +507,10 @@ table.payments td.label {
 		}
 		.footerSectionTitle {
 			clear: both;
+		}
+		.notesTitle {
+			float: left;
+			width: 100%;
 		}
 
 		.thankyou {
@@ -970,7 +975,27 @@ table.payments td.label {
 						{% endif %}
 					{% endfor %}
 					<tr><td width="100%">Totaal belasting</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
-					<tr class="total"><td>Totaal</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% set cash_total = 0 %}
+                    {% set non_cash_total = 0 %}
+                    {% for Payment in Sale.SalePayments.SalePayment %}
+                        {% if Payment.PaymentType.code == "Cash" %}
+                            {% set cash_total = cash_total + Payment.amount|floatval %}
+                        {% else %}
+                            {% set non_cash_total = non_cash_total + Payment.amount|floatval %}
+                        {% endif %}
+                    {% endfor %}
+                        {% set roundedCashTotal = ((cash_total * 20) | round) / 20 %}
+                        {% set roundedTotal = roundedCashTotal + non_cash_total %}
+                    {% if roundedTotal != Sale.calcTotal %}
+                        {% if Sale.completed == "false" and Sale.quoteID > 0 %}
+                            <tr class="total"><td>Totaal</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                        {% else %}
+                            <tr class="total"><td>Totaal</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                            <tr class="total"><td>Afgerond totaal</td><td id="receiptSaleTotalsRoundedTotal" class="amount">{{roundedTotal|money}}</td></tr>
+                        {% endif %}
+                    {% else %}
+                        <tr class="total"><td>Totaal</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}
@@ -1355,24 +1380,45 @@ table.payments td.label {
 {% endmacro %}
 
 {% macro sale_cash_payment(Sale) %}
-	{% set total = Sale.change|floatval %}
-	{% set pay_cash = 'false' %}
-	{% for Payment in Sale.SalePayments.SalePayment %}
-		{% if Payment.PaymentType.name == 'Cash' and Payment.archived == 'false' %}
-			{% set total = total + Payment.amount|floatval %}
-			{% set pay_cash = 'true' %}
+	{% set cashTotal = 0 %}
+	{% set payCash = 'false' %}
+		{% for Payment in Sale.SalePayments.SalePayment %}
+			{% if Payment.PaymentType.code == 'Cash' %}
+            	{% set cashTotal = cashTotal + Payment.amount|floatval %}
+            	{% set payCash = 'true' %}
+        	{% endif %}
+    	{% endfor %}
+	{% if payCash == 'true' %}
+		{% set roundedCashChange = (((Sale.change|floatval) * 20) | round) / 20 %}
+		{% set roundedCashAmount = (((cashTotal * 20)|round) / 20) %}
+		{% set originalCashPayedTotalValue = Sale.change|floatval + cashTotal %}
+		{% set roundedCashPayedTotalValue = roundedCashAmount + Sale.change|floatval %}
+			<tr><td>Contant betaald bedrag</td><td>{{originalCashPayedTotalValue|money}}</td></tr>
+		{% if originalCashPayedTotalValue == roundedCashPayedTotalValue %}
+        	<tr><td class="label">Contant</td><td id="receiptPaymentsCash" class="amount">{{cashTotal|money}}</td></tr>
+        	{% if (Sale.change|floatval) != roundedCashChange %}
+        	<tr><td class="label">Wisselgeld</td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
+        	<tr><td class="label"> Wisselgeld afgerond </td><td id="receiptRoundedPaymentsChange" class="amount">{{roundedCashChange|money}}</td></tr>
+        	{% else %}
+        	<tr><td class="label">Wisselgeld</td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
+        	{% endif %}
+		{% else %}
+        	<tr><td class="label">Contant</td><td id="receiptPaymentsCash" class="amount">{{cashTotal|money}}</td></tr>
+        	<tr><td class="label">Totaal contant afgerond </td><td id="receiptRoundedPaymentsCash" class="amount">{{roundedCashAmount|money}}</td></tr>
+        	{% if (Sale.change|floatval) != roundedCashChange %}
+        	<tr><td class="label">Wisselgeld </td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
+        	<tr><td class="label"> Wisselgeld afgerond </td><td id="receiptRoundedPaymentsChange" class="amount">{{roundedCashChange|money}}</td></tr>
+        	{% else %}
+        	<tr><td class="label">Wisselgeld </td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
+        	{% endif %}
 		{% endif %}
-	{% endfor %}
-	{% if pay_cash == 'true' %}
-		<tr><td class="label">Contant</td><td id="receiptPaymentsCash" class="amount">{{total|money}}</td></tr>
-		<tr><td class="label">Wisselgeld</td><td id="receiptPaymentsChange" class="amount">{{Sale.change|money}}</td></tr>
-	{% endif %}
+   	{% endif %}
 {% endmacro %}
 
 {% macro show_note(SaleNotes) %}
 	{% for SaleNote in SaleNotes %}
 		{% if SaleNote.PrintedNote and SaleNote.PrintedNote.note != '' %}
-			<h2 class="paymentTitle">AANTEKENINGEN</h2>
+			<h2 class="notesTitle">AANTEKENINGEN</h2>
 			<table>
 				<tr>
 					<td>

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -499,6 +499,7 @@ table.payments td.label {
 		}
 
 		.paymentTitle,
+		.notesTitle,
 		.footerSectionTitle {
 			font-size: 12pt;
 			padding-top: 15px;
@@ -506,6 +507,10 @@ table.payments td.label {
 		}
 		.footerSectionTitle {
 			clear: both;
+		}
+		.notesTitle {
+			float: left;
+			width: 100%;
 		}
 
 		.thankyou {
@@ -1372,7 +1377,7 @@ table.payments td.label {
 {% macro show_note(SaleNotes) %}
 	{% for SaleNote in SaleNotes %}
 		{% if SaleNote.PrintedNote and SaleNote.PrintedNote.note != '' %}
-			<h2 class="paymentTitle">AANTEKENINGEN</h2>
+			<h2 class="notesTitle">AANTEKENINGEN</h2>
 			<table>
 				<tr>
 					<td>


### PR DESCRIPTION
- FIX internal notes display when the print_layout is true
- Added words Montant payé en espèces and Contant betaald bedrag respectively for amount paid in cash
- Added conditional checking whether the sale was completed and the quoteID was gt 1 to remove rounded total