### PR TITLE
[CLD-28966] Added workorder internal notes to tag

### DIFF
--- a/workorder/default.tpl
+++ b/workorder/default.tpl
@@ -322,6 +322,15 @@ img.barcode {
                 </div>
             {% endif %}
 
+            {% if parameters.type == 'shop-tag' %}
+                {% if Workorder.internalNote|strlen > 0 %}
+                    <div class="notes">
+                        <h3>Internal Notes:</h3>
+                        {{ Workorder.internalNote|noteformat|raw }}
+                    </div>
+                {% endif %}
+            {% endif %}
+
             <img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Workorder.systemSku}}">
             
             {% if parameters.type == 'invoice' %}


### PR DESCRIPTION
Added the internal notes secction on a work order
tag.

<img width="1679" alt="tag" src="https://user-images.githubusercontent.com/47331824/74849163-67868600-5306-11ea-9d18-823eea6c68e9.png">
