### PR TITLE
[CLD-31719] Add internal notes on custom workorder template

### DIFF
--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -434,6 +434,15 @@ img.barcode {
 				{% endif %}
 			{% endif %}
 
+			{% if parameters.type == 'shop-tag' %}
+				{% if Workorder.internalNote|strlen > 0 %}
+					<div class="notes">
+						<h3>Internal Notes:</h3>
+						{{ Workorder.internalNote|noteformat|raw }}
+					</div>
+				{% endif %}
+			{% endif %}
+
 			{% if hide_barcode == false %}
 				{% if hide_barcode_sku == true %}
            			{% set hide_text = 1 %}


### PR DESCRIPTION
Added internal notes section to custom work order template:

![image](https://user-images.githubusercontent.com/71656269/94311975-1e587d80-ff4a-11ea-8d58-e121864fb3f0.png)
