### PR TITLE
Add filter to accommodate multi-currency symbol

### DIFF
--- a/purchase_order/purchase_order.tpl
+++ b/purchase_order/purchase_order.tpl
@@ -222,7 +222,7 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 <tr>
 <td>
 {% if Order.MetaData.shipping|strlen > 0 %}
-{{Order.MetaData.shipping|money}}
+{{Order.MetaData.shipping|format_currency}}
 {% else %}
 <i>None</i>
 {% endif %} 
@@ -239,7 +239,7 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 {% endif %}
 <td>
 {% if Order.MetaData.other|strlen > 0 %} 
-{{Order.MetaData.other|money}}
+{{Order.MetaData.other|format_currency}}
 {% else %}
 <i>None</i>
 {% endif %}
@@ -287,8 +287,8 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 <td>{{OrderLine.Item.upc}}</td>
 <td>{{OrderLine.Item.description}}</td>
 <td>{{OrderLine.quantity}}</td>
-<td class="money">{{OrderLine.MetaData.cost|money}}</td>
-<td class="money">{{OrderLine.MetaData.total|money}}</td>
+<td class="money">{{OrderLine.MetaData.cost|format_currency}}</td>
+<td class="money">{{OrderLine.MetaData.total|format_currency}}</td>
 </tr>
 {% endfor %}
 <tfoot>
@@ -299,7 +299,7 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 {% endif %}
 <td></td>
 <td></td>
-<td class="money">{{Order.MetaData.subtotal|money}}</td>
+<td class="money">{{Order.MetaData.subtotal|format_currency}}</td>
 </tr>
 {% if Order.MetaData.totalDiscount > 0 %}
 <tr class="minor">
@@ -307,7 +307,7 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 <th></th>
 <td></td>
 <td></td>
-<td class="money">{{Order.MetaData.totalDiscount|getinverse|money}}</td>
+<td class="money">{{Order.MetaData.totalDiscount|format_currency({invert: true})}}</td>
 </tr>
 {% endif %}
 <tr class="total">
@@ -317,7 +317,7 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 {% endif %}
 <td></td>
 <td></td>
-<td class="money">{{Order.MetaData.total|money}}</td>
+<td class="money">{{Order.MetaData.total|format_currency}}</td>
 </tr>
 </tfoot>
 </table>


### PR DESCRIPTION
This will allow customers with multi-currency to see the respective vendor currency symbol in the PO template.  This is made possible with the addition of a custom twig filter "format_currency". Latest version of twig already implements this filter but we are still on an older version of twig at the moment

PR with the new filter https://github.com/merchantos/webPOS/pull/16764