### PR TITLE
PO data patch for issues with new the LS Retail 'mulitple vendor fields'

### DIFF
--- a/purchase_order/purchase_order.tpl
+++ b/purchase_order/purchase_order.tpl
@@ -278,11 +278,13 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 {% for OrderLine in Order.OrderLines.OrderLine %}
 <tr>
 <td>
-{% if OrderLine.Item.ItemVendorNums.ItemVendorNum.value|strlen > 0 %}
-{{OrderLine.Item.ItemVendorNums.ItemVendorNum.value}}
-{% else %}
-<em>None</em>
-{% endif %} 
+    {% for Lines in OrderLine.Item.ItemVendorNums.ItemVendorNum if Lines.vendorID == Order.Vendor.vendorID|number_format  %}
+        {% if Lines.value|strlen > 0 %}
+        {{Lines.value}}
+        {% else %}
+        <em>None</em>
+        {% endif %} 
+    {% endfor %}
 </td>
 <td>{{OrderLine.Item.upc}}</td>
 <td>{{OrderLine.Item.description}}</td>

--- a/purchase_order/purchase_order.tpl
+++ b/purchase_order/purchase_order.tpl
@@ -289,10 +289,17 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 <td>{{OrderLine.Item.upc}}</td>
 <td>{{OrderLine.Item.description}}</td>
 <td>{{OrderLine.quantity}}</td>
-<td class="money">{{OrderLine.MetaData.cost|money}}</td>
-<td class="money">{{OrderLine.MetaData.total|money}}</td>
-</tr>
+{% for Lines in OrderLine.Item.ItemVendorNums.ItemVendorNum if Lines.vendorID == Order.Vendor.vendorID|number_format  %}
+    {% if (Lines.cost|raw) != (OrderLine.MetaData.cost|raw) %}
+        <td class="money">{{Lines.cost|money}}</td>
+        <td class="money">{{(Lines.cost * OrderLine.quantity)|money}}</td>
+    {% else %}
+        <td class="money">{{OrderLine.MetaData.cost|money}}</td>
+        <td class="money">{{OrderLine.MetaData.total|money}}</td>
+    {% endif %}
 {% endfor %}
+</tr>
+
 <tfoot>
 <tr class="minor">
 <th>Subtotal</th>

--- a/purchase_order/purchase_order.tpl
+++ b/purchase_order/purchase_order.tpl
@@ -299,7 +299,7 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
     {% endif %}
 {% endfor %}
 </tr>
-
+{% endfor %}
 <tfoot>
 <tr class="minor">
 <th>Subtotal</th>


### PR DESCRIPTION
There was a new feature in Retail that now allows multiple entries for vendor SKU and cost data. This patch will ensure that the correct data is applied to the PO if multiple vendors exist.