### PR TITLE
LSR-3339 Sync Template Updates

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -1007,6 +1007,9 @@ table.payments td.label {
 					{% endfor %}
 					<tr><td width="100%">Total Tax</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
 					<tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% if Sale.tipEnabled == 'true' %}
+                        <tr class="tip"><td>Tip</td><td id="receiptSaleTotalsTip" class="amount">{{Sale.calcTips|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}

--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -106,7 +106,6 @@ body {
 
 .store {
 	page-break-after: always;
-	margin-bottom: 40px;
 }
 
 .receipt {
@@ -639,7 +638,7 @@ table.payments td.label {
 
 {% macro store_receipt(Sale,parameters,options,Payment) %}
 	<div class="store">
-        {{ _self.header(Sale,_context) }}
+        {{ _self.header(Sale,options) }}
 		{{ _self.title(Sale,parameters,options) }}
 			<p class="copy">Store Copy</p>
 		{{ _self.date(Sale) }}
@@ -663,7 +662,9 @@ table.payments td.label {
 		{{ _self.cc_agreement(Sale,Payment,options) }}
 		{{ _self.shop_workorder_agreement(Sale) }}
 
-		<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		<p class="barcodeContainer">
+			<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		</p>
 
 		{{ _self.ship_to(Sale,options) }}
 	</div>
@@ -882,7 +883,7 @@ table.payments td.label {
 
 {% macro line(isTaxInclusive,Line,parameters,options) %}
 	<tr>
-		<th data-automation="lineItemDescription" class="description">
+		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
@@ -891,7 +892,7 @@ table.payments td.label {
 					<small>Discount: '{{ Line.Discount.name }}' {{Line.calcLineDiscount|getinverse|money}}</small>
 				{% endif %}
 			{% endif %}
-		</th>
+		</td>
 
 		{% if options.show_custom_sku and Line.Item.customSku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
@@ -1163,28 +1164,28 @@ table.payments td.label {
 
 {% macro transaction(Payment) %}
     {% if Payment.PaymentType.type == 'credit card' and Payment.MetaData.ReceiptData.status != 'error' and Payment.archived == 'false' %}
-        {% if Payment.MetaData.ReceiptData.type and Payment.MetaData.ReceiptData.authorized_amount %}
+        {% if Payment.MetaData.ReceiptData.type|strlen and Payment.MetaData.ReceiptData.authorized_amount|strlen %}
             <tr>
                 <td class="label top">{{ mostranslate(Payment.MetaData.ReceiptData.type, 'capitalize', true) }}</td>
                 <td class="top">{{ Payment.MetaData.ReceiptData.authorized_amount|money }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.extra_parameters.statusCode %}
+        {% if Payment.MetaData.ReceiptData.extra_parameters.statusCode|strlen %}
             <tr>
                 <td class="label">Status:</td>
                 <td>{{ Payment.MetaData.ReceiptData.extra_parameters.statusCode }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.card_brand and Payment.MetaData.ReceiptData.card_number %}
+        {% if Payment.MetaData.ReceiptData.card_brand|strlen and Payment.MetaData.ReceiptData.card_number|strlen %}
             <tr>
                 <td class="label">{{ Payment.MetaData.ReceiptData.card_brand }}</td>
                 <td>{{ getDisplayableCardNumber(Payment.MetaData.ReceiptData.card_number) }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.processed_date %}
+        {% if Payment.MetaData.ReceiptData.processed_date|strlen %}
             <tr>
                 <td class="label">Date:</td>
                 <td>
@@ -1193,59 +1194,59 @@ table.payments td.label {
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.entry_method %}
+        {% if Payment.MetaData.ReceiptData.entry_method|strlen %}
             <tr>
                 <td class="label">Method:</td>
                 <td>{{ Payment.MetaData.ReceiptData.entry_method }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.extra_parameters.acceptorId %}
+        {% if Payment.MetaData.ReceiptData.extra_parameters.acceptorId|strlen %}
             <tr>
                 <td class="label">MLC:</td>
                 <td>{{ Payment.MetaData.ReceiptData.extra_parameters.acceptorId }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.authorization_number %}
+        {% if Payment.MetaData.ReceiptData.authorization_number|strlen %}
             <tr>
                 <td class="label">Auth Code:</td>
                 <td>{{ Payment.MetaData.ReceiptData.authorization_number }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkCode or Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkMessage %}
+        {% if Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkCode|strlen or Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkMessage|strlen %}
             <tr>
                 <td class="label">Response:</td>
                 <td>{{ Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkCode }}/{{ Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkMessage }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.emv_application_id %}
+        {% if Payment.MetaData.ReceiptData.emv_application_id|strlen %}
             <tr>
                 <td class="label">AID:</td>
                 <td>{{ Payment.MetaData.ReceiptData.emv_application_id }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.emv_application_preferred_name %}
+        {% if Payment.MetaData.ReceiptData.emv_application_preferred_name|strlen %}
             <tr>
                 <td class="label">APN:</td>
                 <td>{{ Payment.MetaData.ReceiptData.emv_application_preferred_name }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.extra_parameters.accountType %}
+        {% if Payment.MetaData.ReceiptData.extra_parameters.accountType|strlen %}
         <tr>
             <td class="label">Account Type:</td>
             <td>{{ Payment.MetaData.ReceiptData.extra_parameters.accountType }}</td>
         </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.emv_cryptogram_type or Payment.MetaData.ReceiptData.emv_cryptogram %}
+        {% if Payment.MetaData.ReceiptData.emv_cryptogram_type|strlen or Payment.MetaData.ReceiptData.emv_cryptogram|strlen %}
             <tr>
                 <td class="label">Cryptogram:</td>
-                <td>{{ Payment.MetaData.ReceiptData.emv_cryptogram_type }}/{{ Payment.MetaData.ReceiptData.emv_cryptogram }}</td>
+                <td>{{ Payment.MetaData.ReceiptData.emv_cryptogram_type }} {{ Payment.MetaData.ReceiptData.emv_cryptogram }}</td>
             </tr>
         {% endif %}
 
@@ -1376,7 +1377,7 @@ table.payments td.label {
 			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -106,7 +106,6 @@ body {
 
 .store {
 	page-break-after: always;
-	margin-bottom: 40px;
 }
 
 .receipt {
@@ -613,7 +612,7 @@ table.payments td.label {
 
 {% macro store_receipt(Sale,parameters,options,Payment) %}
 	<div class="store">
-        {{ _self.header(Sale,_context) }}
+        {{ _self.header(Sale,options) }}
 		{{ _self.title(Sale,parameters,options) }}
 			<p class="copy">Geschäfts-Kopie</p>
 		{{ _self.date(Sale) }}
@@ -633,7 +632,9 @@ table.payments td.label {
 		{{ _self.cc_agreement(Sale,Payment,options) }}
 		{{ _self.shop_workorder_agreement(Sale) }}
 
-		<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		<p class="barcodeContainer">
+			<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		</p>
 
 		{{ _self.ship_to(Sale,options) }}
 	</div>
@@ -852,7 +853,7 @@ table.payments td.label {
 
 {% macro line(isTaxInclusive,Line,parameters,options) %}
 	<tr>
-		<th data-automation="lineItemDescription" class="description">
+		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
@@ -861,7 +862,7 @@ table.payments td.label {
 					<small>Rabatt: '{{ Line.Discount.name }}' {{Line.calcLineDiscount|getinverse|money}}</small>
 				{% endif %}
 			{% endif %}
-		</th>
+		</td>
 
 		{% if options.show_custom_sku and Line.Item.customSku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
@@ -1214,7 +1215,7 @@ table.payments td.label {
 			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -977,6 +977,9 @@ table.payments td.label {
 					{% endfor %}
 					<tr><td width="100%">Total Steuern</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
 					<tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% if Sale.tipEnabled == 'true' %}
+                        <tr class="tip"><td>Trinkgeld</td><td id="receiptSaleTotalsTip" class="amount">{{Sale.calcTips|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -106,7 +106,6 @@ body {
 
 .store {
 	page-break-after: always;
-	margin-bottom: 40px;
 }
 
 .receipt {
@@ -613,7 +612,7 @@ table.payments td.label {
 
 {% macro store_receipt(Sale,parameters,options,Payment) %}
 	<div class="store">
-        {{ _self.header(Sale,_context) }}
+        {{ _self.header(Sale,options) }}
 		{{ _self.title(Sale,parameters,options) }}
 			<p class="copy">Copia para la tienda</p>
 		{{ _self.date(Sale) }}
@@ -633,7 +632,9 @@ table.payments td.label {
 		{{ _self.cc_agreement(Sale,Payment,options) }}
 		{{ _self.shop_workorder_agreement(Sale) }}
 
-		<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		<p class="barcodeContainer">
+			<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		</p>
 
 		{{ _self.ship_to(Sale,options) }}
 	</div>
@@ -852,7 +853,7 @@ table.payments td.label {
 
 {% macro line(isTaxInclusive,Line,parameters,options) %}
 	<tr>
-		<th data-automation="lineItemDescription" class="description">
+		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
@@ -861,7 +862,7 @@ table.payments td.label {
 					<small>Descuento: '{{ Line.Discount.name }}' {{Line.calcLineDiscount|getinverse|money}}</small>
 				{% endif %}
 			{% endif %}
-		</th>
+		</td>
 
 		{% if options.show_custom_sku and Line.Item.customSku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
@@ -1214,7 +1215,7 @@ table.payments td.label {
 			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -977,6 +977,9 @@ table.payments td.label {
 					{% endfor %}
 					<tr><td width="100%">Total impuestos</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
 					<tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% if Sale.tipEnabled == 'true' %}
+                        <tr class="tip"><td>Propina</td><td id="receiptSaleTotalsTip" class="amount">{{Sale.calcTips|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -997,6 +997,9 @@ table.payments td.label {
                     {% else %}
                         <tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
                     {% endif %}
+                    {% if Sale.tipEnabled == 'true' %}
+                        <tr class="tip"><td>Pourboire</td><td id="receiptSaleTotalsTip" class="amount">{{Sale.calcTips|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -106,7 +106,6 @@ body {
 
 .store {
 	page-break-after: always;
-	margin-bottom: 40px;
 }
 
 .receipt {
@@ -613,7 +612,7 @@ table.payments td.label {
 
 {% macro store_receipt(Sale,parameters,options,Payment) %}
 	<div class="store">
-        {{ _self.header(Sale,_context) }}
+        {{ _self.header(Sale,options) }}
 		{{ _self.title(Sale,parameters,options) }}
 			<p class="copy">Copie du magasin</p>
 		{{ _self.date(Sale) }}
@@ -633,7 +632,9 @@ table.payments td.label {
 		{{ _self.cc_agreement(Sale,Payment,options) }}
 		{{ _self.shop_workorder_agreement(Sale) }}
 
-		<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		<p class="barcodeContainer">
+			<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		</p>
 
 		{{ _self.ship_to(Sale,options) }}
 	</div>
@@ -852,7 +853,7 @@ table.payments td.label {
 
 {% macro line(isTaxInclusive,Line,parameters,options) %}
 	<tr>
-		<th data-automation="lineItemDescription" class="description">
+		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
@@ -861,7 +862,7 @@ table.payments td.label {
 					<small>Réduction: '{{ Line.Discount.name }}' {{Line.calcLineDiscount|getinverse|money}}</small>
 				{% endif %}
 			{% endif %}
-		</th>
+		</td>
 
 		{% if options.show_custom_sku and Line.Item.customSku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
@@ -1234,7 +1235,7 @@ table.payments td.label {
 			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -110,7 +110,6 @@ body {
 
 .store {
 	page-break-after: always;
-	margin-bottom: 40px;
 }
 
 .receipt {
@@ -612,7 +611,8 @@ table.payments td.label {
 					<img id="barcodeImage" height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}&hide_text={{ not show_barcode_sku }}">
 				</p>
 				{% endif %}
-                {% if Sale.completed == 'true' and Sale.SalePayments and not parameters.gift_receipt %}
+
+				{% if Sale.completed == 'true' and Sale.SalePayments and not parameters.gift_receipt %}
 					{#
 						DO NOT CONSOLIDATE THESE IF STATEMENTS.
 						Twig doesnt play nice with these functions.
@@ -642,7 +642,7 @@ table.payments td.label {
 
 {% macro store_receipt(Sale,parameters,options,Payment) %}
 	<div class="store">
-        {{ _self.header(Sale,_context) }}
+        {{ _self.header(Sale,options) }}
 		{{ _self.title(Sale,parameters,options) }}
 			<p class="copy">Copie du magasin</p>
 		{{ _self.date(Sale) }}
@@ -885,7 +885,7 @@ table.payments td.label {
 
 {% macro line(isTaxInclusive,Line,parameters,options) %}
 	<tr>
-		<th data-automation="lineItemDescription" class="description">
+		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
@@ -894,7 +894,7 @@ table.payments td.label {
 					<small>Réduction : '{{ Line.Discount.name }}' {{Line.calcLineDiscount|getinverse|money}}</small>
 				{% endif %}
 			{% endif %}
-		</th>
+		</td>
 
 		{% if options.show_custom_sku and Line.Item.customSku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
@@ -1172,107 +1172,6 @@ table.payments td.label {
 	</tr>
 {% endmacro %}
 
-
-{% macro transaction(Payment) %}
-    {% if Payment.PaymentType.type == 'credit card' and Payment.MetaData.ReceiptData.status != 'error' and Payment.archived == 'false' %}
-        {% if Payment.MetaData.ReceiptData.type and Payment.MetaData.ReceiptData.authorized_amount %}
-            <tr>
-                <td class="label top">{{ mostranslate(Payment.MetaData.ReceiptData.type, 'capitalize', true) }}</td>
-                <td class="top">{{ Payment.MetaData.ReceiptData.authorized_amount|money }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.extra_parameters.statusCode %}
-            <tr>
-                <td class="label">Statut :</td>
-                <td>{{ Payment.MetaData.ReceiptData.extra_parameters.statusCode }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.card_brand and Payment.MetaData.ReceiptData.card_number %}
-            <tr>
-                <td class="label">{{ Payment.MetaData.ReceiptData.card_brand }}</td>
-                <td>{{ getDisplayableCardNumber(Payment.MetaData.ReceiptData.card_number) }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.processed_date %}
-            <tr>
-                <td class="label">Date :</td>
-                <td>
-                    {{ Payment.MetaData.ReceiptData.processed_date|correcttimezone|date(getDateTimeFormat()) }}
-                </td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.entry_method %}
-            <tr>
-                <td class="label">Méthode :</td>
-                <td>{{ Payment.MetaData.ReceiptData.entry_method }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.extra_parameters.acceptorId %}
-            <tr>
-                <td class="label">Identifiant de niveau marchand :</td>
-                <td>{{ Payment.MetaData.ReceiptData.extra_parameters.acceptorId }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.authorization_number %}
-            <tr>
-                <td class="label">Code d'autorisation :</td>
-                <td>{{ Payment.MetaData.ReceiptData.authorization_number }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkCode or Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkMessage %}
-            <tr>
-                <td class="label">Réponse :</td>
-                <td>{{ Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkCode }}/{{ Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkMessage }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.emv_application_id %}
-            <tr>
-                <td class="label">ID de l'application :</td>
-                <td>{{ Payment.MetaData.ReceiptData.emv_application_id }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.emv_application_preferred_name %}
-            <tr>
-                <td class="label">ID du point d'accès :</td>
-                <td>{{ Payment.MetaData.ReceiptData.emv_application_preferred_name }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.extra_parameters.accountType %}
-            <tr>
-                <td class="label">Type de compte :</td>
-                <td>{{ Payment.MetaData.ReceiptData.extra_parameters.accountType }}</td>
-            </tr>
-        {% endif %}
-
-        {% if Payment.MetaData.ReceiptData.emv_cryptogram_type or Payment.MetaData.ReceiptData.emv_cryptogram %}
-            <tr>
-                <td class="label">Cryptogramme :</td>
-                <td>{{ Payment.MetaData.ReceiptData.emv_cryptogram_type }}/{{ Payment.MetaData.ReceiptData.emv_cryptogram }}</td>
-            </tr>
-        {% endif %}
-
-        {% for emvTag in Payment.MetaData.ReceiptData.extra_parameters.emv_tags.children() %}
-            <tr>
-                <td class="label">{{ emvTag.getName() }}</td>
-                <td>{{ emvTag }}</td>
-            </tr>
-        {% endfor %}
-
-        {# Creates a Line Break for the next Payment #}
-        <tr><td colspan="2"><br /></td></tr>
-    {% endif %}
-{% endmacro %}
-
 {% macro single_transaction_details(Sale, Payment) %}
     {% if hasCCPayment(Sale.SalePayments) %}
         {% if isUnifiedReceipt(Sale.SalePayments) %}
@@ -1307,7 +1206,7 @@ table.payments td.label {
 
 {% macro transaction(Payment) %}
     {% if Payment.PaymentType.type == 'credit card' and Payment.MetaData.ReceiptData.status != 'error' and Payment.archived == 'false' %}
-        {% if Payment.MetaData.ReceiptData.type and Payment.MetaData.ReceiptData.authorized_amount %}
+        {% if Payment.MetaData.ReceiptData.type|strlen and Payment.MetaData.ReceiptData.authorized_amount|strlen %}
             <tr>
                 {% if Payment.MetaData.ReceiptData.type == 'sale' %}
                     <td class="label top">VENTE</td>
@@ -1318,7 +1217,7 @@ table.payments td.label {
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.extra_parameters.statusCode %}
+        {% if Payment.MetaData.ReceiptData.extra_parameters.statusCode|strlen %}
             <tr>
                 <td class="label">Statut :</td>
                 <td>
@@ -1333,14 +1232,14 @@ table.payments td.label {
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.card_brand and Payment.MetaData.ReceiptData.card_number %}
+        {% if Payment.MetaData.ReceiptData.card_brand|strlen and Payment.MetaData.ReceiptData.card_number|strlen %}
             <tr>
                 <td class="label">{{ Payment.MetaData.ReceiptData.card_brand }}</td>
                 <td>{{ getDisplayableCardNumber(Payment.MetaData.ReceiptData.card_number) }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.processed_date %}
+        {% if Payment.MetaData.ReceiptData.processed_date|strlen %}
             <tr>
                 <td class="label">Date :</td>
                 <td>
@@ -1349,59 +1248,59 @@ table.payments td.label {
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.entry_method %}
+        {% if Payment.MetaData.ReceiptData.entry_method|strlen %}
             <tr>
                 <td class="label">Méthode :</td>
                 <td>{{ Payment.MetaData.ReceiptData.entry_method }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.extra_parameters.acceptorId %}
+        {% if Payment.MetaData.ReceiptData.extra_parameters.acceptorId|strlen %}
             <tr>
                 <td class="label">MLC :</td>
                 <td>{{ Payment.MetaData.ReceiptData.extra_parameters.acceptorId }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.authorization_number %}
+        {% if Payment.MetaData.ReceiptData.authorization_number|strlen %}
             <tr>
                 <td class="label">Code d'autorisation :</td>
                 <td>{{ Payment.MetaData.ReceiptData.authorization_number }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkCode or Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkMessage %}
+        {% if Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkCode|strlen or Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkMessage|strlen %}
             <tr>
                 <td class="label">Response :</td>
                 <td>{{ Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkCode }}/{{ Payment.MetaData.ReceiptData.extra_parameters.authorizationNetworkMessage }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.emv_application_id %}
+        {% if Payment.MetaData.ReceiptData.emv_application_id|strlen %}
             <tr>
                 <td class="label">ID d'application :</td>
                 <td>{{ Payment.MetaData.ReceiptData.emv_application_id }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.emv_application_preferred_name %}
+        {% if Payment.MetaData.ReceiptData.emv_application_preferred_name|strlen %}
             <tr>
                 <td class="label">Identifiant du point d'accès :</td>
                 <td>{{ Payment.MetaData.ReceiptData.emv_application_preferred_name }}</td>
             </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.extra_parameters.accountType %}
+        {% if Payment.MetaData.ReceiptData.extra_parameters.accountType|strlen %}
         <tr>
             <td class="label">Type de compte :</td>
             <td>{{ Payment.MetaData.ReceiptData.extra_parameters.accountType }}</td>
         </tr>
         {% endif %}
 
-        {% if Payment.MetaData.ReceiptData.emv_cryptogram_type or Payment.MetaData.ReceiptData.emv_cryptogram %}
+        {% if Payment.MetaData.ReceiptData.emv_cryptogram_type|strlen or Payment.MetaData.ReceiptData.emv_cryptogram|strlen %}
             <tr>
                 <td class="label">Cryptogramme :</td>
-                <td>{{ Payment.MetaData.ReceiptData.emv_cryptogram_type }}/{{ Payment.MetaData.ReceiptData.emv_cryptogram }}</td>
+                <td>{{ Payment.MetaData.ReceiptData.emv_cryptogram_type }} {{ Payment.MetaData.ReceiptData.emv_cryptogram }}</td>
             </tr>
         {% endif %}
 
@@ -1533,7 +1432,7 @@ table.payments td.label {
 			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -1009,6 +1009,9 @@ table.payments td.label {
 					{% endfor %}
 					<tr><td width="100%">Total des taxes</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
 					<tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% if Sale.tipEnabled == 'true' %}
+                        <tr class="tip"><td>Pourboire</td><td id="receiptSaleTotalsTip" class="amount">{{Sale.calcTips|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -106,7 +106,6 @@ body {
 
 .store {
 	page-break-after: always;
-	margin-bottom: 40px;
 }
 
 .receipt {
@@ -613,7 +612,7 @@ table.payments td.label {
 
 {% macro store_receipt(Sale,parameters,options,Payment) %}
 	<div class="store">
-        {{ _self.header(Sale,_context) }}
+        {{ _self.header(Sale,options) }}
 		{{ _self.title(Sale,parameters,options) }}
 			<p class="copy">Copie de la boutique</p>
 		{{ _self.date(Sale) }}
@@ -633,7 +632,9 @@ table.payments td.label {
 		{{ _self.cc_agreement(Sale,Payment,options) }}
 		{{ _self.shop_workorder_agreement(Sale) }}
 
-		<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		<p class="barcodeContainer">
+			<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		</p>
 
 		{{ _self.ship_to(Sale,options) }}
 	</div>
@@ -1214,7 +1215,7 @@ table.payments td.label {
 			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -977,6 +977,9 @@ table.payments td.label {
 					{% endfor %}
 					<tr><td width="100%">Total des taxes</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
 					<tr class="total"><td>Total</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% if Sale.tipEnabled == 'true' %}
+                        <tr class="tip"><td>Pourboire</td><td id="receiptSaleTotalsTip" class="amount">{{Sale.calcTips|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -106,7 +106,6 @@ body {
 
 .store {
 	page-break-after: always;
-	margin-bottom: 40px;
 }
 
 .receipt {
@@ -613,7 +612,7 @@ table.payments td.label {
 
 {% macro store_receipt(Sale,parameters,options,Payment) %}
 	<div class="store">
-        {{ _self.header(Sale,_context) }}
+        {{ _self.header(Sale,options) }}
 		{{ _self.title(Sale,parameters,options) }}
 			<p class="copy">Winkelbon</p>
 		{{ _self.date(Sale) }}
@@ -633,7 +632,9 @@ table.payments td.label {
 		{{ _self.cc_agreement(Sale,Payment,options) }}
 		{{ _self.shop_workorder_agreement(Sale) }}
 
-		<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		<p class="barcodeContainer">
+			<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		</p>
 
 		{{ _self.ship_to(Sale,options) }}
 	</div>
@@ -852,7 +853,7 @@ table.payments td.label {
 
 {% macro line(isTaxInclusive,Line,parameters,options) %}
 	<tr>
-		<th data-automation="lineItemDescription" class="description">
+		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
@@ -861,7 +862,7 @@ table.payments td.label {
 					<small>Korting: '{{ Line.Discount.name }}' {{Line.calcLineDiscount|getinverse|money}}</small>
 				{% endif %}
 			{% endif %}
-		</th>
+		</td>
 
 		{% if options.show_custom_sku and Line.Item.customSku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
@@ -1234,7 +1235,7 @@ table.payments td.label {
 			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -997,6 +997,9 @@ table.payments td.label {
                     {% else %}
                         <tr class="total"><td>Totaal</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
                     {% endif %}
+                    {% if Sale.tipEnabled == 'true' %}
+                        <tr class="tip"><td>Fooi</td><td id="receiptSaleTotalsTip" class="amount">{{Sale.calcTips|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -977,6 +977,9 @@ table.payments td.label {
 					{% endfor %}
 					<tr><td width="100%">Totaal belasting</td><td id="receiptSaleTotalsTax" class="amount">{{Sale.taxTotal|money}}</td></tr>
 					<tr class="total"><td>Totaal</td><td id="receiptSaleTotalsTotal" class="amount">{{Sale.calcTotal|money}}</td></tr>
+                    {% if Sale.tipEnabled == 'true' %}
+                        <tr class="tip"><td>Fooi</td><td id="receiptSaleTotalsTip" class="amount">{{Sale.calcTips|money}}</td></tr>
+                    {% endif %}
 				</tbody>
 			</table>
 		{% endif %}

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -106,7 +106,6 @@ body {
 
 .store {
 	page-break-after: always;
-	margin-bottom: 40px;
 }
 
 .receipt {
@@ -613,7 +612,7 @@ table.payments td.label {
 
 {% macro store_receipt(Sale,parameters,options,Payment) %}
 	<div class="store">
-        {{ _self.header(Sale,_context) }}
+        {{ _self.header(Sale,options) }}
 		{{ _self.title(Sale,parameters,options) }}
 			<p class="copy">Winkelbon</p>
 		{{ _self.date(Sale) }}
@@ -633,7 +632,9 @@ table.payments td.label {
 		{{ _self.cc_agreement(Sale,Payment,options) }}
 		{{ _self.shop_workorder_agreement(Sale) }}
 
-		<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		<p class="barcodeContainer">
+			<img height="50" width="250" class="barcode" src="/barcode.php?type=receipt&number={{Sale.ticketNumber}}">
+		</p>
 
 		{{ _self.ship_to(Sale,options) }}
 	</div>
@@ -852,7 +853,7 @@ table.payments td.label {
 
 {% macro line(isTaxInclusive,Line,parameters,options) %}
 	<tr>
-		<th data-automation="lineItemDescription" class="description">
+		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
@@ -861,7 +862,7 @@ table.payments td.label {
 					<small>Korting: '{{ Line.Discount.name }}' {{Line.calcLineDiscount|getinverse|money}}</small>
 				{% endif %}
 			{% endif %}
-		</th>
+		</td>
 
 		{% if options.show_custom_sku and Line.Item.customSku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
@@ -1214,7 +1215,7 @@ table.payments td.label {
 			{% for shop in options.shop_logo_array if not logo_printed %}
 				{% if shop.name == Sale.Shop.name %}
 					{% if shop.logo_url|strlen > 0 %}
-						<img src="{{ shop.logo_url }}" width ={{ options.logo_width }} height="{{ options.logo_height }}" class="logo">
+						<img src="{{ shop.logo_url }}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
 						{% set logo_printed = true %}
 					{% endif %}
 				{% endif %}


### PR DESCRIPTION
Sync minor updates from previous work:
- Remove 40px margin-bottom on `.store`
- Wrap barcode in `p.barcodeContainer`
- Replace `th` with `td`
- Remove duplicated macro declaration
- Harden "exist" validation strategy with `strlen` for `if` statements
- Hide empty payment fields

New capability:
- Display tip value when applicable.