### PR TITLE
LSR-13378: Custom Template for Purchase Order is not displaying the correct Vendor ID

### DIFF
--- a/purchase_order/purchase_order.tpl
+++ b/purchase_order/purchase_order.tpl
@@ -278,11 +278,11 @@ Expected: {{Order.arrivalDate|correcttimezone|date ("m/d/y")}}<br />
 {% for OrderLine in Order.OrderLines.OrderLine %}
 <tr>
 <td>
-{% if OrderLine.Item.ItemVendorNums.ItemVendorNum.value|strlen > 0 %}
-{{OrderLine.Item.ItemVendorNums.ItemVendorNum.value}}
-{% else %}
-<em>None</em>
-{% endif %} 
+{% for ItemVendorNum in OrderLine.Item.ItemVendorNums.ItemVendorNum %}
+{% if (Order.vendorID|number_format) == (ItemVendorNum.vendorID|number_format) %}
+{{ ItemVendorNum.value }}
+{% endif %}
+{% endfor %}
 </td>
 <td>{{OrderLine.Item.upc}}</td>
 <td>{{OrderLine.Item.description}}</td>


### PR DESCRIPTION
Previously, the first vendor ID in the list would be chosen, now the vendor ID that matches the PO vendor will print, else the field will be blank.