### PR TITLE
LSR-13879: Fix workorder template address section

### DIFF
--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -290,7 +290,11 @@ img.barcode {
 				<p id="customerName">{{ Workorder.Customer.firstName}} {{ Workorder.Customer.lastName}}</p>
 				<p id="customerAddress1">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
 				<p id="customerAddress2">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
-				<p id="customerAddressCity">{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
+				<p id="customerAddressCity">
+          {{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.city and (Workorder.Customer.Contact.Addresses.ContactAddress.state or Workorder.Customer.Contact.Addresses.ContactAddress.zip) %},{% endif %}
+          {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} 
+          {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}
+        </p>
 				<p id="customerCompany">{{ Workorder.Customer.company }}
 				{% for ContactPhone in Workorder.Customer.Contact.Phones.ContactPhone %}
 					<p data-automation="customerPhoneNumber">{{ ContactPhone.number }} ({{ ContactPhone.useType }})</p>

--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -291,10 +291,10 @@ img.barcode {
 				<p id="customerAddress1">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
 				<p id="customerAddress2">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
 				<p id="customerAddressCity">
-          {{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.city and (Workorder.Customer.Contact.Addresses.ContactAddress.state or Workorder.Customer.Contact.Addresses.ContactAddress.zip) %},{% endif %}
-          {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} 
-          {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}
-        </p>
+				  {{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.city and (Workorder.Customer.Contact.Addresses.ContactAddress.state or Workorder.Customer.Contact.Addresses.ContactAddress.zip) %},{% endif %}
+				  {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} 
+				  {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}
+				</p>
 				<p id="customerCompany">{{ Workorder.Customer.company }}
 				{% for ContactPhone in Workorder.Customer.Contact.Phones.ContactPhone %}
 					<p data-automation="customerPhoneNumber">{{ ContactPhone.number }} ({{ ContactPhone.useType }})</p>

--- a/workorder/customizable_workorder_QC.tpl
+++ b/workorder/customizable_workorder_QC.tpl
@@ -285,7 +285,11 @@ img.barcode {
                 <p id="customerName">{{ Workorder.Customer.firstName}} {{ Workorder.Customer.lastName}}</p>
                 <p id="customerAddress1">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
                 <p id="customerAddress2">{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
-                <p id="customerAddressCity">{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
+                <p id="customerAddressCity">
+                  {{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.city and (Workorder.Customer.Contact.Addresses.ContactAddress.state or Workorder.Customer.Contact.Addresses.ContactAddress.zip) %},{% endif %}
+                  {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }}
+                  {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}
+                </p>
                 <p id="customerCompany">{{ Workorder.Customer.company }}
                 {% for ContactPhone in Workorder.Customer.Contact.Phones.ContactPhone %}
                     <p data-automation="customerPhoneNumber">{{ ContactPhone.number }} ({{ ContactPhone.useType }})</p>

--- a/workorder/default.tpl
+++ b/workorder/default.tpl
@@ -175,7 +175,11 @@ img.barcode {
                 <p>{{ Workorder.Customer.firstName}} {{ Workorder.Customer.lastName}}</p>
                 <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
                 <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
-                <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}, {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }} {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}</p>
+				        <p>
+                  {{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.city and (Workorder.Customer.Contact.Addresses.ContactAddress.state or Workorder.Customer.Contact.Addresses.ContactAddress.zip) %},{% endif %}
+                  {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }}
+                  {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}
+                </p>
                 {% for ContactPhone in Workorder.Customer.Contact.Phones.ContactPhone %}
                     <p>{{ ContactPhone.number }} ({{ ContactPhone.useType }})</p>
                 {% endfor %}

--- a/workorder/default.tpl
+++ b/workorder/default.tpl
@@ -175,7 +175,7 @@ img.barcode {
                 <p>{{ Workorder.Customer.firstName}} {{ Workorder.Customer.lastName}}</p>
                 <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.address1 }}</p>
                 <p>{{ Workorder.Customer.Contact.Addresses.ContactAddress.address2 }}</p>
-				        <p>
+		<p>
                   {{ Workorder.Customer.Contact.Addresses.ContactAddress.city }}{% if Workorder.Customer.Contact.Addresses.ContactAddress.city and (Workorder.Customer.Contact.Addresses.ContactAddress.state or Workorder.Customer.Contact.Addresses.ContactAddress.zip) %},{% endif %}
                   {{ Workorder.Customer.Contact.Addresses.ContactAddress.state }}
                   {{ Workorder.Customer.Contact.Addresses.ContactAddress.zip }}


### PR DESCRIPTION
Previously when a customer's address was not filled in, or not full information there could be a trailing comma in this section.