### PR TITLE
LSR-13687: Print templates - show_shop_name_with_logo = false doesn't remove shop name from custom SaleReceipt

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -1389,7 +1389,7 @@ table.payments td.label {
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
 			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
-			{% if show_shop_name_with_logo == true %}
+			{% if options.show_shop_name_with_logo == true %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
 		{% else %}

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -1227,7 +1227,7 @@ table.payments td.label {
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
 			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
-			{% if show_shop_name_with_logo == true %}
+			{% if options.show_shop_name_with_logo == true %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
 		{% else %}

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -1227,7 +1227,7 @@ table.payments td.label {
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
 			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
-			{% if show_shop_name_with_logo == true %}
+			{% if options.show_shop_name_with_logo == true %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
 		{% else %}

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -1247,7 +1247,7 @@ table.payments td.label {
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
 			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
-			{% if show_shop_name_with_logo == true %}
+			{% if options.show_shop_name_with_logo == true %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
 		{% else %}

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -1444,7 +1444,7 @@ table.payments td.label {
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
 			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
-			{% if show_shop_name_with_logo == true %}
+			{% if options.show_shop_name_with_logo == true %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
 		{% else %}

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -1227,7 +1227,7 @@ table.payments td.label {
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
 			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
-			{% if show_shop_name_with_logo == true %}
+			{% if options.show_shop_name_with_logo == true %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
 		{% else %}

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -1247,7 +1247,7 @@ table.payments td.label {
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
 			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
-			{% if show_shop_name_with_logo == true %}
+			{% if options.show_shop_name_with_logo == true %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
 		{% else %}

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -1227,7 +1227,7 @@ table.payments td.label {
 
 		{% if Sale.Shop.ReceiptSetup.logo|strlen > 0 and not logo_printed %}
 			<img src="{{Sale.Shop.ReceiptSetup.logo}}" width="{{ options.logo_width }}" height="{{ options.logo_height }}" class="logo">
-			{% if show_shop_name_with_logo == true %}
+			{% if options.show_shop_name_with_logo == true %}
 				<h3 class="receiptShopName">{{ Sale.Shop.name }}</h3>
 			{% endif %}
 		{% else %}


### PR DESCRIPTION
The error I was getting was that even if show_shop_name_with_logo was set to true, it wouldn't show as the macros seem to have their own scope. Adjustment is `options.show_shop_name_with_logo`