### PR TITLE
LSR-5340: Work Orders show Price excluding Taxes on the receipt in Tax Inclusive environment when the template is ON

### DIFF
--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -7,7 +7,7 @@ Set any of the options in this section from 'false' to 'true' in order to enable
 {% set firefox_margin_fix = false %}				{# Fixes issue with margins cutting off when printing on a letter printer on a Mac #}
 
 {% set itemized_hours_labor = false %}				{# Shows time spent on Labor item if time spent is present in the charge #}
-{% set per_line_subtotal = true %}					{# Displays Subtotals for each Sale Line (ex. 1 x $5.00) #}
+{% set per_line_subtotal = false %}					{# Displays Subtotals for each Sale Line (ex. 1 x $5.00) #}
 {% set employee_name_on_labor_charges = false %}	{# Display Employee name on Labor Charges #}
 {% set make_work_order_number_small = false %}		{# Makes work order number inline with the header #}
 {% set remove_logo = false %}						{# Removes logo from receipt #}

--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -514,9 +514,9 @@ img.barcode {
 		{% endif %}
 		<td data-automation="lineItemRowCharge" class="amount">
 			{% if Line.warranty == 'false' %}
-        			{{Line.SaleLine.displayableSubtotal|money}}
+			    {{Line.SaleLine.displayableSubtotal|money}}
 			{% elseif Line.warranty == 'true' %}
-				$0.00
+			    $0.00
 			{% endif %}
 		</td>
 	</tr>

--- a/workorder/customizable_workorder.tpl
+++ b/workorder/customizable_workorder.tpl
@@ -7,7 +7,7 @@ Set any of the options in this section from 'false' to 'true' in order to enable
 {% set firefox_margin_fix = false %}				{# Fixes issue with margins cutting off when printing on a letter printer on a Mac #}
 
 {% set itemized_hours_labor = false %}				{# Shows time spent on Labor item if time spent is present in the charge #}
-{% set per_line_subtotal = false %}					{# Displays Subtotals for each Sale Line (ex. 1 x $5.00) #}
+{% set per_line_subtotal = true %}					{# Displays Subtotals for each Sale Line (ex. 1 x $5.00) #}
 {% set employee_name_on_labor_charges = false %}	{# Display Employee name on Labor Charges #}
 {% set make_work_order_number_small = false %}		{# Makes work order number inline with the header #}
 {% set remove_logo = false %}						{# Removes logo from receipt #}
@@ -514,9 +514,9 @@ img.barcode {
 		{% endif %}
 		<td data-automation="lineItemRowCharge" class="amount">
 			{% if Line.warranty == 'false' %}
-				{{Line.SaleLine.calcSubtotal|money}}
-			{% elseif Line.warranty == 'true' %}
-				$0.00
+        {{Line.SaleLine.displayableSubtotal|money}}
+			  {% elseif Line.warranty == 'true' %}
+				  $0.00
 			{% endif %}
 		</td>
 	</tr>

--- a/workorder/customizable_workorder_QC.tpl
+++ b/workorder/customizable_workorder_QC.tpl
@@ -501,7 +501,7 @@ img.barcode {
         {% endif %}
         <td data-automation="lineItemRowCharge" class="amount">
             {% if Line.warranty == 'false' %}
-                {{Line.SaleLine.calcSubtotal|money}}
+                {{Line.SaleLine.displayableSubtotal|money}}
             {% elseif Line.warranty == 'true' %}
                 $0.00
             {% endif %}


### PR DESCRIPTION
See explanations and screenshots on [LSR-5340](https://jira.atlightspeed.net/browse/LSR-5340)