### PR TITLE
LSR-14158: Incorrect strike out price when an item is discounted from a Price Rule.

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -916,7 +916,7 @@ table.payments td.label {
 
 		<td data-automation="lineItemQuantity" class="quantity">
 			{% if options.per_line_subtotal and options.discounted_line_items and Line.calcLineDiscount != 0 and not parameters.gift_receipt %}
-				<span class="strike">{{Line.unitQuantity}} x {{Line.displayableUnitPrice|money}}</span>
+				<span class="strike">{{Line.unitQuantity}} x {{Line.unitPrice|money}}</span>
 			{% endif %}
 			{{Line.unitQuantity}}
 			{% if options.per_line_subtotal and not parameters.gift_receipt %} x
@@ -934,7 +934,7 @@ table.payments td.label {
 					{% if not isTaxInclusive or isTaxInclusive == 'false' %}
 						<span class="strike">{{ Line.calcSubtotal|money }}</span><br />
 					{% else %}
-						<span class="strike">{{ multiply(Line.displayableUnitPrice, Line.unitQuantity)|money }}</span><br />
+						<span class="strike">{{ multiply(Line.unitPrice, Line.unitQuantity)|money }}</span><br />
 					{% endif %}
 				{% endif %}
 				{{ Line.displayableSubtotal|money }}

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -916,7 +916,7 @@ table.payments td.label {
 
 		<td data-automation="lineItemQuantity" class="quantity">
 			{% if options.per_line_subtotal and options.discounted_line_items and Line.calcLineDiscount != 0 and not parameters.gift_receipt %}
-				<span class="strike">{{Line.unitQuantity}} x {{Line.displayableUnitPrice|money}}</span>
+				<span class="strike">{{Line.unitQuantity}} x {{Line.unitPrice|money}}</span>
 			{% endif %}
 			{{Line.unitQuantity}}
 			{% if options.per_line_subtotal and not parameters.gift_receipt %} x
@@ -934,7 +934,7 @@ table.payments td.label {
 					{% if not isTaxInclusive or isTaxInclusive == 'false' %}
 						<span class="strike">{{ Line.calcSubtotal|money }}</span><br />
 					{% else %}
-						<span class="strike">{{ multiply(Line.displayableUnitPrice, Line.unitQuantity)|money }}</span><br />
+						<span class="strike">{{ multiply(Line.unitPrice, Line.unitQuantity)|money }}</span><br />
 					{% endif %}
 				{% endif %}
 				{{ Line.displayableSubtotal|money }}

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -916,7 +916,7 @@ table.payments td.label {
 
 		<td data-automation="lineItemQuantity" class="quantity">
 			{% if options.per_line_subtotal and options.discounted_line_items and Line.calcLineDiscount != 0 and not parameters.gift_receipt %}
-				<span class="strike">{{Line.unitQuantity}} x {{Line.displayableUnitPrice|money}}</span>
+				<span class="strike">{{Line.unitQuantity}} x {{Line.unitPrice|money}}</span>
 			{% endif %}
 			{{Line.unitQuantity}}
 			{% if options.per_line_subtotal and not parameters.gift_receipt %} x
@@ -934,7 +934,7 @@ table.payments td.label {
 					{% if not isTaxInclusive or isTaxInclusive == 'false' %}
 						<span class="strike">{{ Line.calcSubtotal|money }}</span><br />
 					{% else %}
-						<span class="strike">{{ multiply(Line.displayableUnitPrice, Line.unitQuantity)|money }}</span><br />
+						<span class="strike">{{ multiply(Line.unitPrice, Line.unitQuantity)|money }}</span><br />
 					{% endif %}
 				{% endif %}
 				{{ Line.displayableSubtotal|money }}

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -916,7 +916,7 @@ table.payments td.label {
 
 		<td data-automation="lineItemQuantity" class="quantity">
 			{% if options.per_line_subtotal and options.discounted_line_items and Line.calcLineDiscount != 0 and not parameters.gift_receipt %}
-				<span class="strike">{{Line.unitQuantity}} x {{Line.displayableUnitPrice|money}}</span>
+				<span class="strike">{{Line.unitQuantity}} x {{Line.unitPrice|money}}</span>
 			{% endif %}
 			{{Line.unitQuantity}}
 			{% if options.per_line_subtotal and not parameters.gift_receipt %} x
@@ -934,7 +934,7 @@ table.payments td.label {
 					{% if not isTaxInclusive or isTaxInclusive == 'false' %}
 						<span class="strike">{{ Line.calcSubtotal|money }}</span><br />
 					{% else %}
-						<span class="strike">{{ multiply(Line.displayableUnitPrice, Line.unitQuantity)|money }}</span><br />
+						<span class="strike">{{ multiply(Line.unitPrice, Line.unitQuantity)|money }}</span><br />
 					{% endif %}
 				{% endif %}
 				{{ Line.displayableSubtotal|money }}

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -920,7 +920,7 @@ table.payments td.label {
 
 		<td data-automation="lineItemQuantity" class="quantity">
 			{% if options.per_line_subtotal and options.discounted_line_items and Line.calcLineDiscount != 0 and not parameters.gift_receipt %}
-				<span class="strike">{{Line.unitQuantity}} x {{Line.displayableUnitPrice|money}}</span>
+				<span class="strike">{{Line.unitQuantity}} x {{Line.unitPrice|money}}</span>
 			{% endif %}
 			{{Line.unitQuantity}}
 			{% if options.per_line_subtotal and not parameters.gift_receipt %} x
@@ -938,7 +938,7 @@ table.payments td.label {
 					{% if not isTaxInclusive or isTaxInclusive == 'false' %}
 						<span class="strike">{{ Line.calcSubtotal|money }}</span><br />
 					{% else %}
-						<span class="strike">{{ multiply(Line.displayableUnitPrice, Line.unitQuantity)|money }}</span><br />
+						<span class="strike">{{ multiply(Line.unitPrice, Line.unitQuantity)|money }}</span><br />
 					{% endif %}
 				{% endif %}
 				{{ Line.displayableSubtotal|money }}

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -916,7 +916,7 @@ table.payments td.label {
 
 		<td data-automation="lineItemQuantity" class="quantity">
 			{% if options.per_line_subtotal and options.discounted_line_items and Line.calcLineDiscount != 0 and not parameters.gift_receipt %}
-				<span class="strike">{{Line.unitQuantity}} x {{Line.displayableUnitPrice|money}}</span>
+				<span class="strike">{{Line.unitQuantity}} x {{Line.unitPrice|money}}</span>
 			{% endif %}
 			{{Line.unitQuantity}}
 			{% if options.per_line_subtotal and not parameters.gift_receipt %} x
@@ -934,7 +934,7 @@ table.payments td.label {
 					{% if not isTaxInclusive or isTaxInclusive == 'false' %}
 						<span class="strike">{{ Line.calcSubtotal|money }}</span><br />
 					{% else %}
-						<span class="strike">{{ multiply(Line.displayableUnitPrice, Line.unitQuantity)|money }}</span><br />
+						<span class="strike">{{ multiply(Line.unitPrice, Line.unitQuantity)|money }}</span><br />
 					{% endif %}
 				{% endif %}
 				{{ Line.displayableSubtotal|money }}

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -916,7 +916,7 @@ table.payments td.label {
 
 		<td data-automation="lineItemQuantity" class="quantity">
 			{% if options.per_line_subtotal and options.discounted_line_items and Line.calcLineDiscount != 0 and not parameters.gift_receipt %}
-				<span class="strike">{{Line.unitQuantity}} x {{Line.displayableUnitPrice|money}}</span>
+				<span class="strike">{{Line.unitQuantity}} x {{Line.unitPrice|money}}</span>
 			{% endif %}
 			{{Line.unitQuantity}}
 			{% if options.per_line_subtotal and not parameters.gift_receipt %} x
@@ -934,7 +934,7 @@ table.payments td.label {
 					{% if not isTaxInclusive or isTaxInclusive == 'false' %}
 						<span class="strike">{{ Line.calcSubtotal|money }}</span><br />
 					{% else %}
-						<span class="strike">{{ multiply(Line.displayableUnitPrice, Line.unitQuantity)|money }}</span><br />
+						<span class="strike">{{ multiply(Line.unitPrice, Line.unitQuantity)|money }}</span><br />
 					{% endif %}
 				{% endif %}
 				{{ Line.displayableSubtotal|money }}

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -916,7 +916,7 @@ table.payments td.label {
 
 		<td data-automation="lineItemQuantity" class="quantity">
 			{% if options.per_line_subtotal and options.discounted_line_items and Line.calcLineDiscount != 0 and not parameters.gift_receipt %}
-				<span class="strike">{{Line.unitQuantity}} x {{Line.displayableUnitPrice|money}}</span>
+				<span class="strike">{{Line.unitQuantity}} x {{Line.unitPrice|money}}</span>
 			{% endif %}
 			{{Line.unitQuantity}}
 			{% if options.per_line_subtotal and not parameters.gift_receipt %} x
@@ -934,7 +934,7 @@ table.payments td.label {
 					{% if not isTaxInclusive or isTaxInclusive == 'false' %}
 						<span class="strike">{{ Line.calcSubtotal|money }}</span><br />
 					{% else %}
-						<span class="strike">{{ multiply(Line.displayableUnitPrice, Line.unitQuantity)|money }}</span><br />
+						<span class="strike">{{ multiply(Line.unitPrice, Line.unitQuantity)|money }}</span><br />
 					{% endif %}
 				{% endif %}
 				{{ Line.displayableSubtotal|money }}


### PR DESCRIPTION
Displayable unit price vs unit price:

displayableUnitPrice | (float) Reflect the current unit price that the customer is charged for after price rule and only price rule percent discount (not fixed).
-- | --



unitPrice | (float) the unit price. May be adjusted by price rules. Can be negative for rebates or other uses, but not for refunds. Refunds are handled through negative unitQuantity
-- | --



### Before:

![Screen Shot 2022-02-11 at 3 47 06 PM](https://user-images.githubusercontent.com/77158965/153668467-ad3d05d9-6902-4aef-bb7d-bb27eaf6d69d.png)


### After:

![Screen Shot 2022-02-11 at 3 48 30 PM](https://user-images.githubusercontent.com/77158965/153668485-beed905b-21ec-43ab-a9d9-1a805c1dd60e.png)


