### PR TITLE
LSR-5345: Fix receipt alignment issue when using sku column

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -895,10 +895,10 @@ table.payments td.label {
 			{% endif %}
 		</td>
 
-		{% if options.show_custom_sku and Line.Item.customSku %}
+		{% if options.show_custom_sku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
 		{% endif %}
-		{% if options.show_manufacturer_sku and Line.Item.manufacturerSku %}
+		{% if options.show_manufacturer_sku %}
 			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
 		{% endif %}
 

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -863,10 +863,10 @@ table.payments td.label {
 			{% endif %}
 		</th>
 
-		{% if options.show_custom_sku and Line.Item.customSku %}
+		{% if options.show_custom_sku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
 		{% endif %}
-		{% if options.show_manufacturer_sku and Line.Item.manufacturerSku %}
+		{% if options.show_manufacturer_sku %}
 			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
 		{% endif %}
 

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -863,10 +863,10 @@ table.payments td.label {
 			{% endif %}
 		</th>
 
-		{% if options.show_custom_sku and Line.Item.customSku %}
+		{% if options.show_custom_sku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
 		{% endif %}
-		{% if options.show_manufacturer_sku and Line.Item.manufacturerSku %}
+		{% if options.show_manufacturer_sku %}
 			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
 		{% endif %}
 

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -863,10 +863,10 @@ table.payments td.label {
 			{% endif %}
 		</th>
 
-		{% if options.show_custom_sku and Line.Item.customSku %}
+		{% if options.show_custom_sku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
 		{% endif %}
-		{% if options.show_manufacturer_sku and Line.Item.manufacturerSku %}
+		{% if options.show_manufacturer_sku %}
 			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
 		{% endif %}
 

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -897,10 +897,10 @@ table.payments td.label {
 			{% endif %}
 		</td>
 
-		{% if options.show_custom_sku and Line.Item.customSku %}
+		{% if options.show_custom_sku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
 		{% endif %}
-		{% if options.show_manufacturer_sku and Line.Item.manufacturerSku %}
+		{% if options.show_manufacturer_sku %}
 			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
 		{% endif %}
 

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -863,10 +863,10 @@ table.payments td.label {
 			{% endif %}
 		</th>
 
-		{% if options.show_custom_sku and Line.Item.customSku %}
+		{% if options.show_custom_sku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
 		{% endif %}
-		{% if options.show_manufacturer_sku and Line.Item.manufacturerSku %}
+		{% if options.show_manufacturer_sku %}
 			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
 		{% endif %}
 

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -863,10 +863,10 @@ table.payments td.label {
 			{% endif %}
 		</th>
 
-		{% if options.show_custom_sku and Line.Item.customSku %}
+		{% if options.show_custom_sku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
 		{% endif %}
-		{% if options.show_manufacturer_sku and Line.Item.manufacturerSku %}
+		{% if options.show_manufacturer_sku %}
 			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
 		{% endif %}
 

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -863,10 +863,10 @@ table.payments td.label {
 			{% endif %}
 		</th>
 
-		{% if options.show_custom_sku and Line.Item.customSku %}
+		{% if options.show_custom_sku %}
 			<td class="custom_field">{{ Line.Item.customSku }}</td>
 		{% endif %}
-		{% if options.show_manufacturer_sku and Line.Item.manufacturerSku %}
+		{% if options.show_manufacturer_sku %}
 			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
 		{% endif %}
 


### PR DESCRIPTION
The issue was that if the option was `true` it would add the header but for the row it would check if there was data to add first. The row `<td/>` needs to be added if the header is added else the table will not be balanced. 

<table>
<tr>
<td>
<h3>Before</h3>
<img width=“400" src="https://user-images.githubusercontent.com/19352322/153656588-9865d632-3349-458f-aba7-23866ab84138.png" />
</td>
<td>
<h3>After</h3>
<img width=“400" src="https://user-images.githubusercontent.com/19352322/153653302-5743e700-2500-4d9f-a1d9-5fd169c45be7.png" />
</td>
</tr>
</table>