### PR TITLE
LSR-18136: show_customer_name_only option in receipt template does not hide company name

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -1113,14 +1113,6 @@ table.payments td.label {
 					</tr>
 				</table>
 			{% endif %}
-      {% if options.show_credit_account_signature %}
-        <dl id="signatureSection" class="signature">
-          <dt>Signature:</dt>
-          <dd>
-            {% if Sale.Customer %}{{Sale.Customer.firstName}} {{Sale.Customer.lastName}}{% endif %}<br />
-          </dd>
-		    </dl>
-      {% endif %} 
 		{% endif %}
 	{% endif %}
 	{% if (not parameters.gift_receipt and not options.hide_notes_in_sale_receipt) or (parameters.gift_receipt and not options.hide_notes_in_gift_receipt) %}

--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -827,7 +827,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Customer %}
-			{% if Sale.Customer.company|strlen > 0 %}
+			{% if Sale.Customer.company|strlen > 0 and not options.show_customer_name_only %}
 				<span class="receiptCompanyNameField"><span class="receiptCompanyNameLabel">Company: </span><span id="receiptCompanyName">{{Sale.Customer.company}}</span><br /></span>
 			{% endif %}
 
@@ -1113,6 +1113,14 @@ table.payments td.label {
 					</tr>
 				</table>
 			{% endif %}
+      {% if options.show_credit_account_signature %}
+        <dl id="signatureSection" class="signature">
+          <dt>Signature:</dt>
+          <dd>
+            {% if Sale.Customer %}{{Sale.Customer.firstName}} {{Sale.Customer.lastName}}{% endif %}<br />
+          </dd>
+		    </dl>
+      {% endif %} 
 		{% endif %}
 	{% endif %}
 	{% if (not parameters.gift_receipt and not options.hide_notes_in_sale_receipt) or (parameters.gift_receipt and not options.hide_notes_in_gift_receipt) %}

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -827,7 +827,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Customer %}
-			{% if Sale.Customer.company|strlen > 0 %}
+			{% if Sale.Customer.company|strlen > 0 and not options.show_customer_name_only %}
 				<span class="receiptCompanyNameField"><span class="receiptCompanyNameLabel">Firma: </span><span id="receiptCompanyName">{{Sale.Customer.company}}</span><br /></span>
 			{% endif %}
 

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -827,7 +827,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Customer %}
-			{% if Sale.Customer.company|strlen > 0 %}
+			{% if Sale.Customer.company|strlen > 0 and not options.show_customer_name_only %}
 				<span class="receiptCompanyNameField"><span class="receiptCompanyNameLabel">Companía: </span><span id="receiptCompanyName">{{Sale.Customer.company}}</span><br /></span>
 			{% endif %}
 

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -827,7 +827,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Customer %}
-			{% if Sale.Customer.company|strlen > 0 %}
+			{% if Sale.Customer.company|strlen > 0 and not options.show_customer_name_only %}
 				<span class="receiptCompanyNameField"><span class="receiptCompanyNameLabel">Entreprise: </span><span id="receiptCompanyName">{{Sale.Customer.company}}</span><br /></span>
 			{% endif %}
 

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -831,7 +831,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Customer %}
-			{% if Sale.Customer.company|strlen > 0 %}
+			{% if Sale.Customer.company|strlen > 0 and not options.show_customer_name_only %}
 				<span class="receiptCompanyNameField"><span class="receiptCompanyNameLabel">Entreprise : </span><span id="receiptCompanyName">{{Sale.Customer.company}}</span><br /></span>
 			{% endif %}
 

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -827,7 +827,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Customer %}
-			{% if Sale.Customer.company|strlen > 0 %}
+			{% if Sale.Customer.company|strlen > 0 and not options.show_customer_name_only %}
 				<span class="receiptCompanyNameField"><span class="receiptCompanyNameLabel">Entreprise: </span><span id="receiptCompanyName">{{Sale.Customer.company}}</span><br /></span>
 			{% endif %}
 

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -827,7 +827,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Customer %}
-			{% if Sale.Customer.company|strlen > 0 %}
+			{% if Sale.Customer.company|strlen > 0 and not options.show_customer_name_only %}
 				<span class="receiptCompanyNameField"><span class="receiptCompanyNameLabel">Bedrijf: </span><span id="receiptCompanyName">{{Sale.Customer.company}}</span><br /></span>
 			{% endif %}
 

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -827,7 +827,7 @@ table.payments td.label {
 		{% endif %}
 
 		{% if Sale.Customer %}
-			{% if Sale.Customer.company|strlen > 0 %}
+			{% if Sale.Customer.company|strlen > 0 and not options.show_customer_name_only %}
 				<span class="receiptCompanyNameField"><span class="receiptCompanyNameLabel">Bedrijf: </span><span id="receiptCompanyName">{{Sale.Customer.company}}</span><br /></span>
 			{% endif %}
 


### PR DESCRIPTION
With change (first screenshot is `show_customer_name_only` set to false, second screenshot is set to true)

![Screen Shot 2022-06-10 at 1 21 53 PM](https://user-images.githubusercontent.com/77158965/173119673-250e956e-aba7-45ba-9b42-6baa34b83b5b.png)
![Screen Shot 2022-06-10 at 1 22 35 PM](https://user-images.githubusercontent.com/77158965/173119676-8a60aee6-6d9c-4b4b-a7b3-0608d963adca.png)
