### PR TITLE
LSR-6698: Fix receipt CustomSKU and ManufacturerSKU columns

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -207,6 +207,12 @@ table div.line_note {
 	padding-left: 10px;
 }
 
+table div.line_extra {
+	text-align: left;
+	padding-left: 10px;
+	font-size: .8em;
+}
+
 table div.line_serial {
 	text-align: left;
 	font-weight: normal;
@@ -885,6 +891,12 @@ table.payments td.label {
 	<tr>
 		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
+			{% if options.show_custom_sku and Line.Item.customSku|strlen > 0 %}
+				<div class="line_extra">Custom SKU: {{ Line.Item.customSku }}</div>
+			{% endif %}
+			{% if options.show_manufacturer_sku and Line.Item.manufacturerSku|strlen > 0 %}
+				<div class="line_extra">Man. SKU: {{ Line.Item.manufacturerSku }}</div>
+			{% endif %}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
 					<small>Discount: '{{ Line.Discount.name }}' -{{Line.calcLineDiscount|money}}</small>
@@ -893,13 +905,6 @@ table.payments td.label {
 				{% endif %}
 			{% endif %}
 		</td>
-
-		{% if options.show_custom_sku %}
-			<td class="custom_field">{{ Line.Item.customSku }}</td>
-		{% endif %}
-		{% if options.show_manufacturer_sku %}
-			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
-		{% endif %}
 
 		{% if options.show_msrp == true and not parameters.gift_receipt %}
 			{% set msrp_printed = false %}
@@ -948,13 +953,6 @@ table.payments td.label {
 		<table class="sale lines">
 			<tr>
 				<th class="description">Items</th>
-
-				{% if options.show_custom_sku and options.show_manufacturer_sku %}
-					<th class="custom_field">Custom SKU</th>
-					<th class="custom_field">Man. SKU </th>
-				{% elseif options.show_custom_sku or options.show_manufacturer_sku %}
-					<th class="custom_field">SKU</th>
-				{% endif %}
 
 				{% if options.show_msrp and not parameters.gift_receipt %}
 					<th class="custom_field">MSRP</th>

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -207,6 +207,12 @@ table div.line_note {
 	padding-left: 10px;
 }
 
+table div.line_extra {
+	text-align: left;
+	padding-left: 10px;
+	font-size: .8em;
+}
+
 table div.line_serial {
 	text-align: left;
 	font-weight: normal;
@@ -885,6 +891,12 @@ table.payments td.label {
 	<tr>
 		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
+			{% if options.show_custom_sku and Line.Item.customSku|strlen > 0 %}
+				<div class="line_extra">Persönliche SKU: {{ Line.Item.customSku }}</div>
+			{% endif %}
+			{% if options.show_manufacturer_sku and Line.Item.manufacturerSku|strlen > 0 %}
+				<div class="line_extra">Manuelle SKU: {{ Line.Item.manufacturerSku }}</div>
+			{% endif %}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
 					<small>Rabatt: '{{ Line.Discount.name }}' -{{Line.calcLineDiscount|money}}</small>
@@ -893,13 +905,6 @@ table.payments td.label {
 				{% endif %}
 			{% endif %}
 		</td>
-
-		{% if options.show_custom_sku %}
-			<td class="custom_field">{{ Line.Item.customSku }}</td>
-		{% endif %}
-		{% if options.show_manufacturer_sku %}
-			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
-		{% endif %}
 
 		{% if options.show_msrp == true and not parameters.gift_receipt %}
 			{% set msrp_printed = false %}
@@ -948,13 +953,6 @@ table.payments td.label {
 		<table class="sale lines">
 			<tr>
 				<th class="description">Artikel</th>
-
-				{% if options.show_custom_sku and options.show_manufacturer_sku %}
-					<th class="custom_field">Persönliche SKU</th>
-					<th class="custom_field">Manuelle SKU</th>
-				{% elseif options.show_custom_sku or options.show_manufacturer_sku %}
-					<th class="custom_field">SKU</th>
-				{% endif %}
 
 				{% if options.show_msrp and not parameters.gift_receipt %}
 					<th class="custom_field">MSRP</th>

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -207,6 +207,12 @@ table div.line_note {
 	padding-left: 10px;
 }
 
+table div.line_extra {
+	text-align: left;
+	padding-left: 10px;
+	font-size: .8em;
+}
+
 table div.line_serial {
 	text-align: left;
 	font-weight: normal;
@@ -885,6 +891,12 @@ table.payments td.label {
 	<tr>
 		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
+			{% if options.show_custom_sku and Line.Item.customSku|strlen > 0 %}
+				<div class="line_extra">SKU perso.: {{ Line.Item.customSku }}</div>
+			{% endif %}
+			{% if options.show_manufacturer_sku and Line.Item.manufacturerSku|strlen > 0 %}
+				<div class="line_extra">SKU ger.: {{ Line.Item.manufacturerSku }}</div>
+			{% endif %}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
 					<small>Descuento: '{{ Line.Discount.name }}' -{{Line.calcLineDiscount|money}}</small>
@@ -893,13 +905,6 @@ table.payments td.label {
 				{% endif %}
 			{% endif %}
 		</td>
-
-		{% if options.show_custom_sku %}
-			<td class="custom_field">{{ Line.Item.customSku }}</td>
-		{% endif %}
-		{% if options.show_manufacturer_sku %}
-			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
-		{% endif %}
 
 		{% if options.show_msrp == true and not parameters.gift_receipt %}
 			{% set msrp_printed = false %}
@@ -948,13 +953,6 @@ table.payments td.label {
 		<table class="sale lines">
 			<tr>
 				<th class="description">Artículo</th>
-
-				{% if options.show_custom_sku and options.show_manufacturer_sku %}
-					<th class="custom_field">SKU perso.</th>
-					<th class="custom_field">SKU ger.</th>
-				{% elseif options.show_custom_sku or options.show_manufacturer_sku %}
-					<th class="custom_field">SKU</th>
-				{% endif %}
 
 				{% if options.show_msrp and not parameters.gift_receipt %}
 					<th class="custom_field">MSRP</th>

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -207,6 +207,12 @@ table div.line_note {
 	padding-left: 10px;
 }
 
+table div.line_extra {
+	text-align: left;
+	padding-left: 10px;
+	font-size: .8em;
+}
+
 table div.line_serial {
 	text-align: left;
 	font-weight: normal;
@@ -885,6 +891,12 @@ table.payments td.label {
 	<tr>
 		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
+			{% if options.show_custom_sku and Line.Item.customSku|strlen > 0 %}
+				<div class="line_extra">SKU pers.: {{ Line.Item.customSku }}</div>
+			{% endif %}
+			{% if options.show_manufacturer_sku and Line.Item.manufacturerSku|strlen > 0 %}
+				<div class="line_extra">SKU man.: {{ Line.Item.manufacturerSku }}</div>
+			{% endif %}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
 					<small>Réduction: '{{ Line.Discount.name }}' -{{Line.calcLineDiscount|money}}</small>
@@ -893,13 +905,6 @@ table.payments td.label {
 				{% endif %}
 			{% endif %}
 		</td>
-
-		{% if options.show_custom_sku %}
-			<td class="custom_field">{{ Line.Item.customSku }}</td>
-		{% endif %}
-		{% if options.show_manufacturer_sku %}
-			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
-		{% endif %}
 
 		{% if options.show_msrp == true and not parameters.gift_receipt %}
 			{% set msrp_printed = false %}
@@ -948,13 +953,6 @@ table.payments td.label {
 		<table class="sale lines">
 			<tr>
 				<th class="description">Article</th>
-
-				{% if options.show_custom_sku and options.show_manufacturer_sku %}
-					<th class="custom_field">SKU pers.</th>
-					<th class="custom_field">SKU man.</th>
-				{% elseif options.show_custom_sku or options.show_manufacturer_sku %}
-					<th class="custom_field">SKU</th>
-				{% endif %}
 
 				{% if options.show_msrp and not parameters.gift_receipt %}
 					<th class="custom_field">PDSF</th>

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -211,6 +211,12 @@ table div.line_note {
 	padding-left: 10px;
 }
 
+table div.line_extra {
+	text-align: left;
+	padding-left: 10px;
+	font-size: .8em;
+}
+
 table div.line_serial {
 	text-align: left;
 	font-weight: normal;
@@ -889,6 +895,12 @@ table.payments td.label {
 	<tr>
 		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
+			{% if options.show_custom_sku and Line.Item.customSku|strlen > 0 %}
+				<div class="line_extra">SKU pers.: {{ Line.Item.customSku }}</div>
+			{% endif %}
+			{% if options.show_manufacturer_sku and Line.Item.manufacturerSku|strlen > 0 %}
+				<div class="line_extra">SKU man.: {{ Line.Item.manufacturerSku }}</div>
+			{% endif %}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
 					<small>Réduction : '{{ Line.Discount.name }}' -{{Line.calcLineDiscount|money}}</small>
@@ -897,13 +909,6 @@ table.payments td.label {
 				{% endif %}
 			{% endif %}
 		</td>
-
-		{% if options.show_custom_sku  %}
-			<td class="custom_field">{{ Line.Item.customSku }}</td>
-		{% endif %}
-		{% if options.show_manufacturer_sku %}
-			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
-		{% endif %}
 
 		{% if options.show_msrp == true and not parameters.gift_receipt %}
 			{% set msrp_printed = false %}
@@ -952,13 +957,6 @@ table.payments td.label {
 		<table class="sale lines">
 			<tr>
 				<th class="description">Article</th>
-
-				{% if options.show_custom_sku and options.show_manufacturer_sku %}
-					<th class="custom_field">SKU pers.</th>
-					<th class="custom_field">SKU man.</th>
-				{% elseif options.show_custom_sku or options.show_manufacturer_sku %}
-					<th class="custom_field">SKU</th>
-				{% endif %}
 
 				{% if options.show_msrp and not parameters.gift_receipt %}
 					<th class="custom_field">PDSF</th>

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -207,6 +207,12 @@ table div.line_note {
 	padding-left: 10px;
 }
 
+table div.line_extra {
+	text-align: left;
+	padding-left: 10px;
+	font-size: .8em;
+}
+
 table div.line_serial {
 	text-align: left;
 	font-weight: normal;
@@ -885,6 +891,12 @@ table.payments td.label {
 	<tr>
 		<th data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
+			{% if options.show_custom_sku and Line.Item.customSku|strlen > 0 %}
+				<div class="line_extra">UGS pers.: {{ Line.Item.customSku }}</div>
+			{% endif %}
+			{% if options.show_manufacturer_sku and Line.Item.manufacturerSku|strlen > 0 %}
+				<div class="line_extra">UGS man.: {{ Line.Item.manufacturerSku }}</div>
+			{% endif %}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
 					<small>Réduction: '{{ Line.Discount.name }}' -{{Line.calcLineDiscount|money}}</small>
@@ -893,13 +905,6 @@ table.payments td.label {
 				{% endif %}
 			{% endif %}
 		</th>
-
-		{% if options.show_custom_sku %}
-			<td class="custom_field">{{ Line.Item.customSku }}</td>
-		{% endif %}
-		{% if options.show_manufacturer_sku %}
-			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
-		{% endif %}
 
 		{% if options.show_msrp == true and not parameters.gift_receipt %}
 			{% set msrp_printed = false %}
@@ -948,13 +953,6 @@ table.payments td.label {
 		<table class="sale lines">
 			<tr>
 				<th class="description">Article</th>
-
-				{% if options.show_custom_sku and options.show_manufacturer_sku %}
-					<th class="custom_field">UGS pers.</th>
-					<th class="custom_field">UGS man.</th>
-				{% elseif options.show_custom_sku or options.show_manufacturer_sku %}
-					<th class="custom_field">UGS</th>
-				{% endif %}
 
 				{% if options.show_msrp and not parameters.gift_receipt %}
 					<th class="custom_field">PDSF</th>

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -207,6 +207,12 @@ table div.line_note {
 	padding-left: 10px;
 }
 
+table div.line_extra {
+	text-align: left;
+	padding-left: 10px;
+	font-size: .8em;
+}
+
 table div.line_serial {
 	text-align: left;
 	font-weight: normal;
@@ -885,6 +891,12 @@ table.payments td.label {
 	<tr>
 		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
+			{% if options.show_custom_sku and Line.Item.customSku|strlen > 0 %}
+				<div class="line_extra">Aangepaste artikelnummer: {{ Line.Item.customSku }}</div>
+			{% endif %}
+			{% if options.show_manufacturer_sku and Line.Item.manufacturerSku|strlen > 0 %}
+				<div class="line_extra">Artikelnummer fabr.: {{ Line.Item.manufacturerSku }}</div>
+			{% endif %}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
 					<small>Korting: '{{ Line.Discount.name }}' -{{Line.calcLineDiscount|money}}</small>
@@ -893,13 +905,6 @@ table.payments td.label {
 				{% endif %}
 			{% endif %}
 		</td>
-
-		{% if options.show_custom_sku %}
-			<td class="custom_field">{{ Line.Item.customSku }}</td>
-		{% endif %}
-		{% if options.show_manufacturer_sku %}
-			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
-		{% endif %}
 
 		{% if options.show_msrp == true and not parameters.gift_receipt %}
 			{% set msrp_printed = false %}
@@ -948,13 +953,6 @@ table.payments td.label {
 		<table class="sale lines">
 			<tr>
 				<th class="description">Product</th>
-
-				{% if options.show_custom_sku and options.show_manufacturer_sku %}
-					<th class="custom_field">Aangepaste artikelnummer</th>
-					<th class="custom_field">Artikelnummer fabr.</th>
-				{% elseif options.show_custom_sku or options.show_manufacturer_sku %}
-					<th class="custom_field">Artikelnummer</th>
-				{% endif %}
 
 				{% if options.show_msrp and not parameters.gift_receipt %}
 					<th class="custom_field">Adviesprijs</th>

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -207,6 +207,12 @@ table div.line_note {
 	padding-left: 10px;
 }
 
+table div.line_extra {
+	text-align: left;
+	padding-left: 10px;
+	font-size: .8em;
+}
+
 table div.line_serial {
 	text-align: left;
 	font-weight: normal;
@@ -885,6 +891,12 @@ table.payments td.label {
 	<tr>
 		<td data-automation="lineItemDescription" class="description">
 			{{ _self.lineDescription(Line,options) }}
+			{% if options.show_custom_sku and Line.Item.customSku|strlen > 0 %}
+				<div class="line_extra">Aangepaste artikelnummer: {{ Line.Item.customSku }}</div>
+			{% endif %}
+			{% if options.show_manufacturer_sku and Line.Item.manufacturerSku|strlen > 0 %}
+				<div class="line_extra">Artikelnummer fabr.: {{ Line.Item.manufacturerSku }}</div>
+			{% endif %}
 			{% if options.per_line_discount == true and not parameters.gift_receipt %}
 				{% if Line.calcLineDiscount > 0 %}
 					<small>Korting: '{{ Line.Discount.name }}' -{{Line.calcLineDiscount|money}}</small>
@@ -893,13 +905,6 @@ table.payments td.label {
 				{% endif %}
 			{% endif %}
 		</td>
-
-		{% if options.show_custom_sku %}
-			<td class="custom_field">{{ Line.Item.customSku }}</td>
-		{% endif %}
-		{% if options.show_manufacturer_sku %}
-			<td class="custom_field">{{ Line.Item.manufacturerSku }}</td>
-		{% endif %}
 
 		{% if options.show_msrp == true and not parameters.gift_receipt %}
 			{% set msrp_printed = false %}
@@ -948,13 +953,6 @@ table.payments td.label {
 		<table class="sale lines">
 			<tr>
 				<th class="description">Product</th>
-
-				{% if options.show_custom_sku and options.show_manufacturer_sku %}
-					<th class="custom_field">Aangepaste artikelnummer</th>
-					<th class="custom_field">Artikelnummer fabr.</th>
-				{% elseif options.show_custom_sku or options.show_manufacturer_sku %}
-					<th class="custom_field">Artikelnummer</th>
-				{% endif %}
 
 				{% if options.show_msrp and not parameters.gift_receipt %}
 					<th class="custom_field">Adviesprijs</th>


### PR DESCRIPTION
## Description

Instead of being columns where text may overflow and the price being pushed out of the printable area, have the `manufacturer sku` and `custom sku` show below the item description.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="600" alt="image" src="https://user-images.githubusercontent.com/19352322/204052788-32191c59-f07e-400b-9c3b-7bd3bbe93b35.png">
</td>
<td>
<img width="600" alt="image" src="https://user-images.githubusercontent.com/19352322/204052678-b80296f9-a5d5-41db-8727-34010b9be701.png">
</td>
</tr>
</table>