### PR TITLE
LSR-22416: Show accurate subtotal for taxInclusive accounts 

### DIFF
--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -984,17 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-                                {% if options.Sale.isTaxInclusive == 'true' %}
-                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
-                                {% else %}
+				                        	{% if options.Sale.isTaxInclusive == 'true' %}
+				                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+				                                {% else %}
 								    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
-							    {% endif %}
+								{% endif %}
 							{% else %}
-                                {% if options.Sale.isTaxInclusive == 'true' %}
-                                    {{ Sale.calcSubtotal|money }}
-                                {% else %}
-                                    {{ Sale.displayableSubtotal|money }}
-							    {% endif %}
+				                                {% if options.Sale.isTaxInclusive == 'true' %}
+				                                    {{ Sale.calcSubtotal|money }}
+				                                {% else %}
+				                                    {{ Sale.displayableSubtotal|money }}
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt.tpl
+++ b/receipt/SaleReceipt.tpl
@@ -984,9 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-								{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money}}
+                                {% if options.Sale.isTaxInclusive == 'true' %}
+                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+                                {% else %}
+								    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+							    {% endif %}
 							{% else %}
-								{{Sale.displayableSubtotal|money}}
+                                {% if options.Sale.isTaxInclusive == 'true' %}
+                                    {{ Sale.calcSubtotal|money }}
+                                {% else %}
+                                    {{ Sale.displayableSubtotal|money }}
+							    {% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -984,17 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
-                                {% else %}
-                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
-                                {% endif %}
-                            {% else %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ Sale.calcSubtotal|money }}
-                                {% else %}
-                                    {{ Sale.displayableSubtotal|money }}
-                                {% endif %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+								{% else %}
+									{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+								{% endif %}
+							{% else %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ Sale.calcSubtotal|money }}
+								{% else %}
+									{{ Sale.displayableSubtotal|money }}
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_de_CH.tpl
+++ b/receipt/SaleReceipt_de_CH.tpl
@@ -984,9 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-								{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money}}
-							{% else %}
-								{{Sale.displayableSubtotal|money}}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+                                {% else %}
+                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+                                {% endif %}
+                            {% else %}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ Sale.calcSubtotal|money }}
+                                {% else %}
+                                    {{ Sale.displayableSubtotal|money }}
+                                {% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -984,17 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
-                                {% else %}
-                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
-                                {% endif %}
-                            {% else %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ Sale.calcSubtotal|money }}
-                                {% else %}
-                                    {{ Sale.displayableSubtotal|money }}
-                                {% endif %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+								{% else %}
+									{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+								{% endif %}
+							{% else %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ Sale.calcSubtotal|money }}
+								{% else %}
+									{{ Sale.displayableSubtotal|money }}
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_es.tpl
+++ b/receipt/SaleReceipt_es.tpl
@@ -984,9 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-								{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money}}
-							{% else %}
-								{{Sale.displayableSubtotal|money}}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+                                {% else %}
+                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+                                {% endif %}
+                            {% else %}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ Sale.calcSubtotal|money }}
+                                {% else %}
+                                    {{ Sale.displayableSubtotal|money }}
+                                {% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -984,17 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
-                                {% else %}
-                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
-                                {% endif %}
-                            {% else %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ Sale.calcSubtotal|money }}
-                                {% else %}
-                                    {{ Sale.displayableSubtotal|money }}
-                                {% endif %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+								{% else %}
+									{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+								{% endif %}
+							{% else %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ Sale.calcSubtotal|money }}
+								{% else %}
+									{{ Sale.displayableSubtotal|money }}
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_fr_BE.tpl
+++ b/receipt/SaleReceipt_fr_BE.tpl
@@ -984,9 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-								{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money}}
-							{% else %}
-								{{Sale.displayableSubtotal|money}}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+                                {% else %}
+                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+                                {% endif %}
+                            {% else %}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ Sale.calcSubtotal|money }}
+                                {% else %}
+                                    {{ Sale.displayableSubtotal|money }}
+                                {% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -988,17 +988,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
-                                {% else %}
-                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
-                                {% endif %}
-                            {% else %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ Sale.calcSubtotal|money }}
-                                {% else %}
-                                    {{ Sale.displayableSubtotal|money }}
-                                {% endif %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+								{% else %}
+									{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+								{% endif %}
+							{% else %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ Sale.calcSubtotal|money }}
+								{% else %}
+									{{ Sale.displayableSubtotal|money }}
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>
@@ -1037,7 +1037,7 @@ table.payments td.label {
 								<!-- Gift Card -->
 								{% if Payment.amount > 0 %}
 									<tr>
-										<td class="label">Prélèvement sur carte cadeau {{Payment.CreditAccount.code}}</td>
+										<td class="label">Prélèvement sur carte cadeau</td>
 										<td id="receiptPaymentsGiftCardValue" class="amount">{{Payment.amount|money}}</td>
 									</tr>
 									<tr>

--- a/receipt/SaleReceipt_fr_CA-QC.tpl
+++ b/receipt/SaleReceipt_fr_CA-QC.tpl
@@ -988,9 +988,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-								{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money}}
-							{% else %}
-								{{Sale.displayableSubtotal|money}}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+                                {% else %}
+                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+                                {% endif %}
+                            {% else %}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ Sale.calcSubtotal|money }}
+                                {% else %}
+                                    {{ Sale.displayableSubtotal|money }}
+                                {% endif %}
 							{% endif %}
 						</td>
 					</tr>
@@ -1029,7 +1037,7 @@ table.payments td.label {
 								<!-- Gift Card -->
 								{% if Payment.amount > 0 %}
 									<tr>
-										<td class="label">Prélèvement sur carte cadeau</td>
+										<td class="label">Prélèvement sur carte cadeau {{Payment.CreditAccount.code}}</td>
 										<td id="receiptPaymentsGiftCardValue" class="amount">{{Payment.amount|money}}</td>
 									</tr>
 									<tr>

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -984,17 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
-                                {% else %}
-                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
-                                {% endif %}
-                            {% else %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ Sale.calcSubtotal|money }}
-                                {% else %}
-                                    {{ Sale.displayableSubtotal|money }}
-                                {% endif %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+								{% else %}
+									{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+								{% endif %}
+							{% else %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ Sale.calcSubtotal|money }}
+								{% else %}
+									{{ Sale.displayableSubtotal|money }}
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_fr_CH.tpl
+++ b/receipt/SaleReceipt_fr_CH.tpl
@@ -984,9 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-								{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money}}
-							{% else %}
-								{{Sale.displayableSubtotal|money}}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+                                {% else %}
+                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+                                {% endif %}
+                            {% else %}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ Sale.calcSubtotal|money }}
+                                {% else %}
+                                    {{ Sale.displayableSubtotal|money }}
+                                {% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -984,17 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
-                                {% else %}
-                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
-                                {% endif %}
-                            {% else %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ Sale.calcSubtotal|money }}
-                                {% else %}
-                                    {{ Sale.displayableSubtotal|money }}
-                                {% endif %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+								{% else %}
+									{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+								{% endif %}
+							{% else %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ Sale.calcSubtotal|money }}
+								{% else %}
+									{{ Sale.displayableSubtotal|money }}
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_nl_BE.tpl
+++ b/receipt/SaleReceipt_nl_BE.tpl
@@ -984,9 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-								{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money}}
-							{% else %}
-								{{Sale.displayableSubtotal|money}}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+                                {% else %}
+                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+                                {% endif %}
+                            {% else %}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ Sale.calcSubtotal|money }}
+                                {% else %}
+                                    {{ Sale.displayableSubtotal|money }}
+                                {% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -984,17 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
-                                {% else %}
-                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
-                                {% endif %}
-                            {% else %}
-                                {% if options.Sale.isTaxInclusive == 'true'%}
-                                    {{ Sale.calcSubtotal|money }}
-                                {% else %}
-                                    {{ Sale.displayableSubtotal|money }}
-                                {% endif %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+								{% else %}
+									{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+								{% endif %}
+							{% else %}
+								{% if options.Sale.isTaxInclusive == 'true'%}
+									{{ Sale.calcSubtotal|money }}
+								{% else %}
+									{{ Sale.displayableSubtotal|money }}
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>

--- a/receipt/SaleReceipt_nl_NL.tpl
+++ b/receipt/SaleReceipt_nl_NL.tpl
@@ -984,9 +984,17 @@ table.payments td.label {
 						</td>
 						<td id="receiptSaleTotalsSubtotal" class="amount">
 							{% if options.discounted_line_items %}
-								{{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money}}
-							{% else %}
-								{{Sale.displayableSubtotal|money}}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ subtract(Sale.calcSubtotal, Sale.calcDiscount)|money }}
+                                {% else %}
+                                    {{ subtract(Sale.displayableSubtotal, Sale.calcDiscount)|money }}
+                                {% endif %}
+                            {% else %}
+                                {% if options.Sale.isTaxInclusive == 'true'%}
+                                    {{ Sale.calcSubtotal|money }}
+                                {% else %}
+                                    {{ Sale.displayableSubtotal|money }}
+                                {% endif %}
 							{% endif %}
 						</td>
 					</tr>


### PR DESCRIPTION
## Description

The `subtotal` amount for `taxInclusive` accounts was inaccurate. This PR fixes that.

**WebPOS PR:** https://github.com/merchantos/webPOS/pull/21670

## Evidence

**Before Fix**

<img width="618" alt="tax_inclusive_before_fix_show_discounts" src="https://github.com/merchantos/webPOS/assets/111370588/6925d9b8-04f6-4151-8dc9-6ca7cfe3c879">
<img width="619" alt="tax_inclusive_before_fix" src="https://github.com/merchantos/webPOS/assets/111370588/f2fdabc4-0f65-4455-9ed5-ad4ed3a2f68c">
<img width="609" alt="tax_excusive_before_fix_show_discounts" src="https://github.com/merchantos/webPOS/assets/111370588/a3e299c9-0208-4729-81b0-a7494b9c0d87">
<img width="613" alt="tax_exclusive_before_fix" src="https://github.com/merchantos/webPOS/assets/111370588/979bf00d-7b5e-4819-8592-29e218fb847c">


**After Fix**


<img width="619" alt="tax_inclusive_after_fix" src="https://github.com/merchantos/webPOS/assets/111370588/8fa2653b-23a9-4aa0-b862-b4d2356b554e">
<img width="617" alt="tax_inclusive_after_fix_show_discounts" src="https://github.com/merchantos/webPOS/assets/111370588/aca28f7b-b876-41b7-9bc9-36e2a7cd8bea">
<img width="614" alt="tax_exclusive_after_fix_show_discounts" src="https://github.com/merchantos/webPOS/assets/111370588/a117659e-3044-4049-b9c7-de30647aecd5">
<img width="614" alt="tax_exclusive_after_fix" src="https://github.com/merchantos/webPOS/assets/111370588/b13a3f0e-bef2-491a-a41a-3993e73290cf">